### PR TITLE
Lower_bound tests with data structure, Minimize and Insertion continued. 

### DIFF
--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -75,11 +75,14 @@ void ModelSelectionMap::insert(double newPenalty, Model newModel){
       //update the placeholder on value instead of returning an error message if penalty is 0.
       if(newPenalty == 0){
          auto placeHolder = penaltyModelMap.find(0.0);
-         placeHolder->second = newModel; 
+         placeHolder->second = newModel;
+         std::cout << "Insert of penalty 0 found, updating placeholder value!\n"; 
       }
          
-
-      std::cout << "Insert failed, key exists!\n";
+      else{
+         std::cout << "Insert failed, key exists and is not 0!\n";
+      }
+      
       return;
    }
 
@@ -99,21 +102,23 @@ void ModelSelectionMap::insert(Model currentModel){};
 MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
    //Default result if we do not find a matching penaltyQuery.
    MinimizeResult queryResult = MinimizeResult(); 
-   auto indexPair = penaltyModelMap.find(penaltyQuery);
+   auto indexPair = penaltyModelMap.lower_bound(penaltyQuery);
    double indexPenalty = indexPair->first;
    Model indexModel = indexPair->second;
 
-    //If we have models inserted, we need to find a penaltyQuery result that is closest to the queried penaltyQuery
-    indexPair = penaltyModelMap.lower_bound(penaltyQuery);
-
     //If we found an inserted pair that lies on the queried penalty itself
-    if(indexPenalty == penaltyQuery)
-    //Make a query result to return using the second element of a testedPair, Model. Get its modelSize. 
-    queryResult = MinimizeResult(std::make_pair(indexModel.modelSize,indexModel.modelSize));
+    if(indexPenalty == penaltyQuery) {
+       //Make a query result to return using the second element of a testedPair, Model. Get its modelSize. 
+       queryResult = MinimizeResult(std::make_pair(indexModel.modelSize,indexModel.modelSize));
+       queryResult.certain = true;
+    }
+    
    
     //Otherwise, make a range query that does not lie on an inserted pair. 
     else{
-       queryResult = MinimizeResult(std::make_pair(indexModel.modelSize, indexModel.modelSizeAfter)); //Returning default for now. 
+       auto prevPair = prev(indexPair);
+       Model prevModel = prevPair->second;
+       queryResult = MinimizeResult(std::make_pair(prevModel.modelSize, indexModel.modelSize)); //Returning default for now. 
        queryResult.certain = false;
     }
     

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -49,17 +49,24 @@ ModelSelectionMap::ModelSelectionMap(int maxModels) : maxModels(maxModels) {
 void ModelSelectionMap::insert(double newPenalty, Model newModel){
    //Insert into ourpenaltyModelPair map in the ModelSelectionMap if the newPenalty is not within it.
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
-   auto nextLowest = penaltyModelMap.lower_bound(newPenalty);
+   auto nextKey = penaltyModelMap.lower_bound(newPenalty);
+   auto prevKey = prev(nextKey);
+    
    try{
       auto insertResult = penaltyModelMap.insert(newPair);
       validateInsert(insertResult);
       //After inserting, update our previous entry as well. 
       prevInsertedPair = insertResult.first; //Set the iterator to the previous insert to the validated insert as we did not error.
+
+      //Note that we inserted a model. 
+      insertedModels++;
+
+   //Update the model before us.    
    }
    catch(std::logic_error errorMessage) {
       std::cout << "Insert failed, key exists!\n";
    }
-   insertedModels++;     
+    
 }
 
 void ModelSelectionMap::insert(Model currentModel){};

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -126,9 +126,7 @@ void ModelSelectionMap::displayMap() {
 
  }
 
- void ModelSelectionMap::updatePreviousEntry(){
-   std::cout << "Updating previous entry based on new insert!\n";
-}
+
 
 
 //General Utilities used in ModelSelectionMap

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -26,7 +26,7 @@ ModelSelectionMap::ModelSelectionMap() : maxModels(STD_MODEL_CAP){
    }
 
    catch(std::logic_error errorMessage) {
-      std::cout << "Insert failed, validation returned an error!\n";
+      std::cout << "Insert failed, key exists!\n";
    }
    insertedModels = 0; //This starts at 0 as we exclude the beginning placeholder. 
 }
@@ -42,7 +42,7 @@ ModelSelectionMap::ModelSelectionMap(int maxModels) : maxModels(maxModels) {
       prevInsertedPair = insertResult.first; //Set the iterator to the previous insert to the validated insert as we did not error.  
    }
    catch(std::logic_error errorMessage) {
-      std::cout << "Insert failed, validation returned an error!\n";
+      std::cout << "Insert failed, key exists!\n";
    }
    insertedModels = 0; //This starts at 0 as we exclude the beginning placeholder.
 }
@@ -59,7 +59,7 @@ ModelSelectionMap::ModelSelectionMap(int maxModels) : maxModels(maxModels) {
    }
 
    catch(std::logic_error errorMessage) {
-      std::cout << "Insert failed, validation returned an error!\n";
+      std::cout << "Insert failed, key exists!\n";
    }
    insertedModels++;     
 }

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -49,11 +49,16 @@ ModelSelectionMap::ModelSelectionMap(int maxModels) : maxModels(maxModels) {
 void ModelSelectionMap::insert(double newPenalty, Model newModel){
    //Insert into ourpenaltyModelPair map in the ModelSelectionMap if the newPenalty is not within it.
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
-   auto nextKey = penaltyModelMap.lower_bound(newPenalty);
-   auto prevKey = prev(nextKey);
+   auto nextHighestKey = penaltyModelMap.lower_bound(newPenalty);
+   std::map<double, Model>::iterator prevKey;
    //If we found a model/penalty pairing that is higher than our current query
-   if(nextKey != penaltyModelMap.end())
-      newPair.second.modelSizeAfter = nextKey->second.modelSize;
+   if(nextHighestKey != penaltyModelMap.end())
+      newPair.second.modelSizeAfter = nextHighestKey->second.modelSize;
+
+   //If the 
+   if(nextHighestKey->first != 0.0){
+      prevKey = prev(nextHighestKey);
+   }
 
    try{
       auto insertResult = penaltyModelMap.insert(newPair);

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -55,7 +55,6 @@ ModelSelectionMap::ModelSelectionMap(int maxModels) : maxModels(maxModels) {
       auto insertResult = penaltyModelMap.insert(newPair);
       validateInsert(insertResult);
       //After inserting, update our previous entry as well. 
-      updatePreviousEntry();
       prevInsertedPair = insertResult.first; //Set the iterator to the previous insert to the validated insert as we did not error.
    }
 
@@ -64,6 +63,8 @@ ModelSelectionMap::ModelSelectionMap(int maxModels) : maxModels(maxModels) {
    }
    insertedModels++;     
 }
+
+void ModelSelectionMap::insert(Model currentModel){};
 
 MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
    //Default result if we do not find a matching penaltyQuery.

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -17,7 +17,6 @@ ModelSelectionMap::ModelSelectionMap() : maxModels(STD_MODEL_CAP){
    //Set a starting point to be stored at penalty 0 using placeholders to be updated. 
    Model startingModel = Model(1,PLACEHOLDER_LOSS);
    startingModel.modelSizeAfter = 1;
-   startingModel.isDefaultQuery = true;
    PenaltyModelPair startingPair = PenaltyModelPair(0.0, startingModel);
    try{
       auto insertResult = penaltyModelMap.insert(startingPair);
@@ -77,8 +76,7 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
 
     //If we found an inserted pair that lies on the queried penalty itself
     if(indexPenalty == penaltyQuery)
-    
-    //Make a query result to return using the second element of a testedPair, Model. Get it's modelSize. 
+    //Make a query result to return using the second element of a testedPair, Model. Get its modelSize. 
     queryResult = MinimizeResult(std::make_pair(indexModel.modelSize,indexModel.modelSize));
    
     //Otherwise, make a range query that does not lie on an inserted pair. 

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -51,7 +51,10 @@ void ModelSelectionMap::insert(double newPenalty, Model newModel){
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
    auto nextKey = penaltyModelMap.lower_bound(newPenalty);
    auto prevKey = prev(nextKey);
-    
+   //If we found a model/penalty pairing that is higher than our current query
+   if(nextKey != penaltyModelMap.end())
+      newPair.second.modelSizeAfter = nextKey->second.modelSize;
+
    try{
       auto insertResult = penaltyModelMap.insert(newPair);
       validateInsert(insertResult);
@@ -64,9 +67,26 @@ void ModelSelectionMap::insert(double newPenalty, Model newModel){
    //Update the model before us.    
    }
    catch(std::logic_error errorMessage) {
+      //update the placeholder on value instead of returning an error message if penalty is 0.
+      if(newPenalty == 0){
+         auto placeHolder = penaltyModelMap.find(0.0);
+         placeHolder->second = newModel; 
+      }
+         
+
       std::cout << "Insert failed, key exists!\n";
+      return;
    }
-    
+
+
+
+   //If we have a key before us, update that key's modelSizeAfter to our newly inserted modelsize. 
+   //if(prevKey != nullptr)
+      //prevKey->second.modelSizeAfter = newPair.second.modelSize;
+   
+   
+
+
 }
 
 void ModelSelectionMap::insert(Model currentModel){};

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -10,7 +10,7 @@ struct Model {
     //Loss associated with the given model 
     double loss = 0.0;
     int modelSizeAfter; //Used for next Model (the after flag in psuedocode)
-    bool isSameAfter; //Used to determine if the current modelSize is the same as the predicted next. 
+    bool isSameAfter; //Used to determine if the current modelSize is the same as the predicted next.
     //Range of penalties for which this model is optimal.
     std::pair<double,double> optimalPenaltyRange;
 };

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -34,7 +34,7 @@ using PenaltyModelPair = std::pair<double, Model>;
 class ModelSelectionMap {
 public:
     //Map constants and return codes.
-    const double PLACEHOLDER_LOSS = -9.0;
+    const double PLACEHOLDER_LOSS = -9999.0;
     const double EMPTY_MAP_QUERY = 0;
     const double EMPTY_MAP_ERR = -99999;
     const double DEFAULT_PENALTY = -9999;   

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -134,7 +134,6 @@ public:
 
 
     private:
-        void updatePreviousEntry();
         bool hasModelsInserted(); //Custom isEmpty method as we will add a initial model, nullifing built-in method.     
 };
 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -77,13 +77,19 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
    
   TEST(MinimizeTests, testLowerBoundInsertion){
     ModelSelectionMap testMap = ModelSelectionMap();
-    Model model3Seg = Model(3, 0.0);
-    Model model2Seg = Model(2, 4.0);
+    Model model3Seg = Model(3, 0.0); //Previous
+    Model model2Seg = Model(2, 4.0); //Given with lower_bound
     testMap.insert(2.0, model3Seg);
-    testMap.insert(4.0, model2Seg);
+    testMap.insert(5.0, model2Seg);
+    testMap.displayMap();
     auto lowerBPair = testMap.penaltyModelMap.lower_bound(3.0);
+    auto prevPair = std::prev(lowerBPair, 1);
+    auto firstPair = std::prev(prevPair, 1);
+    int prevModelSize = prevPair->second.modelSize;
     int lowerBoundModelSize = lowerBPair->second.modelSize;
     ASSERT_EQ(2, lowerBoundModelSize);
+    ASSERT_EQ(3, prevModelSize);
+    ASSERT_EQ(1, firstPair->second.modelSize);
   }
 
    TEST(InsertTests, DISABLED_testDuplicatePenalty){

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -75,7 +75,7 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
    }
 
    
-  TEST(MinimizeTests, testLowerBoundInsertion){
+  TEST(InsertTests, testLowerBoundInsertion){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model3Seg = Model(3, 0.0); //Previous
     Model model2Seg = Model(2, 4.0); //Given with lower_bound

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -81,13 +81,14 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
     Model model2Seg = Model(2, 4.0); //Given with lower_bound
     testMap.insert(2.0, model3Seg);
     auto lowerBeforeInserts = testMap.penaltyModelMap.lower_bound(5.0);
+    
     ASSERT_EQ(lowerBeforeInserts, testMap.penaltyModelMap.end());
     ASSERT_EQ(prev(lowerBeforeInserts)->first, 2.0);
     testMap.insert(5.0, model2Seg);
     testMap.displayMap();
     auto lowerBAfterInserts = testMap.penaltyModelMap.lower_bound(3.0);
-    auto prevPair = std::prev(lowerBAfterInserts, 1);
-    auto firstPair = std::prev(prevPair, 1);
+    auto prevPair = prev(lowerBAfterInserts);
+    auto firstPair = prev(lowerBAfterInserts, 2);
     int prevModelSize = prevPair->second.modelSize;
     int lowerBoundModelSize = lowerBAfterInserts->second.modelSize;
     ASSERT_EQ(2, lowerBoundModelSize);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -80,13 +80,16 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
     Model model3Seg = Model(3, 0.0); //Previous
     Model model2Seg = Model(2, 4.0); //Given with lower_bound
     testMap.insert(2.0, model3Seg);
+    auto lowerBeforeInserts = testMap.penaltyModelMap.lower_bound(5.0);
+    ASSERT_EQ(lowerBeforeInserts, testMap.penaltyModelMap.end());
+    ASSERT_EQ(prev(lowerBeforeInserts)->first, 2.0);
     testMap.insert(5.0, model2Seg);
     testMap.displayMap();
-    auto lowerBPair = testMap.penaltyModelMap.lower_bound(3.0);
-    auto prevPair = std::prev(lowerBPair, 1);
+    auto lowerBAfterInserts = testMap.penaltyModelMap.lower_bound(3.0);
+    auto prevPair = std::prev(lowerBAfterInserts, 1);
     auto firstPair = std::prev(prevPair, 1);
     int prevModelSize = prevPair->second.modelSize;
-    int lowerBoundModelSize = lowerBPair->second.modelSize;
+    int lowerBoundModelSize = lowerBAfterInserts->second.modelSize;
     ASSERT_EQ(2, lowerBoundModelSize);
     ASSERT_EQ(3, prevModelSize);
     ASSERT_EQ(1, firstPair->second.modelSize);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -32,7 +32,7 @@ void testMinimize(MinimizeResult testResult, double lowModelSize, bool certainFl
 void testGetPen(ModelSelectionMap testMap, double expectedPenalty ){
     GTEST_GETPENCOUT << "Running test for getNextPenalty\n\n";
 
-    EXPECT_EQ(testMap.getNewPenaltyList(), expectedPenalty) << "Penalty returned by getNewPenalty differs from expected.\n";
+    EXPECT_EQ(testMap.getNewPenalty(), expectedPenalty) << "Penalty returned by getNewPenalty differs from expected.\n";
     
 }
 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -38,13 +38,13 @@ void testGetPen(ModelSelectionMap testMap, double expectedPenalty ){
 
 
 //Tests to ensure correct model formation and associated logic.
-TEST(ModelTests, DISABLED_modelTest){
+TEST(ModelCreationTests, DISABLED_modelTest){
     Model model3segs = Model(3, 5);
     ASSERT_EQ(model3segs.modelSize, 3);
    }
 
    
-TEST(ModelTests, DISABLED_modelLossTestPos){
+TEST(ModelCreationTests, DISABLED_modelLossTestPos){
     Model model3segs = Model(3, 5);
     ASSERT_EQ(model3segs.loss, 5);
 
@@ -73,6 +73,18 @@ TEST(ModelTests, DISABLED_modelLossTestPos){
     ModelSelectionMap testMap = ModelSelectionMap();
     testMinimize(testMap.minimize(0.5), 1, false, 0.5);
    }
+
+   
+  TEST(MinimizeTests, testLowerBoundInsertion){
+    ModelSelectionMap testMap = ModelSelectionMap();
+    Model model3Seg = Model(3, 0.0);
+    Model model2Seg = Model(2, 4.0);
+    testMap.insert(2.0, model3Seg);
+    testMap.insert(4.0, model2Seg);
+    auto lowerBPair = testMap.penaltyModelMap.lower_bound(3.0);
+    int lowerBoundModelSize = lowerBPair->second.modelSize;
+    ASSERT_EQ(2, lowerBoundModelSize);
+  }
 
    TEST(InsertTests, DISABLED_testDuplicatePenalty){
     ModelSelectionMap testMap = ModelSelectionMap();

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -129,20 +129,8 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
 
    }
 
-
-  /*TEST(InsertTests, testRangeUpdate){
-    ModelSelectionMap testMap = ModelSelectionMap();
-    double expectedStart = 3.0;
-    double expectedEnd = 5.0;
-    Model model1Seg = Model(1, 7.0);
-    testMap.insert(3.0, model1Seg);
-    testMap.insert(5.0, model1Seg); //Currently this will work with two entries, need to update range instead. 
-    EXPECT_EQ(model1Seg.optimalPenaltyRange.first, expectedStart);
-    EXPECT_EQ(model1Seg.optimalPenaltyRange.second, expectedEnd); //Right now these should fail. 
-   }*/
-
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(DISABLED_InsertTests, testInsertLeftPanel){
+ TEST(InsertTests, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(testMap.STD_MODEL_CAP);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -76,24 +76,24 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
 
    
   TEST(InsertTests, testLowerBoundInsertion){
-    ModelSelectionMap testMap = ModelSelectionMap();
+    ModelSelectionMap testMap = ModelSelectionMap(); //Create a new model selection map class
     Model model3Seg = Model(3, 0.0); //Previous
     Model model2Seg = Model(2, 4.0); //Given with lower_bound
-    testMap.insert(2.0, model3Seg);
-    auto lowerBeforeInserts = testMap.penaltyModelMap.lower_bound(5.0);
+    testMap.insert(2.0, model3Seg); //Insert the three segment model at penalty 3.0.
+    auto lowerBeforeInserts = testMap.penaltyModelMap.lower_bound(3.0); //This returns map::end as no key exceeds 3.0
     
-    ASSERT_EQ(lowerBeforeInserts, testMap.penaltyModelMap.end());
-    ASSERT_EQ(prev(lowerBeforeInserts)->first, 2.0);
-    testMap.insert(5.0, model2Seg);
-    testMap.displayMap();
-    auto lowerBAfterInserts = testMap.penaltyModelMap.lower_bound(3.0);
-    auto prevPair = prev(lowerBAfterInserts);
-    auto firstPair = prev(lowerBAfterInserts, 2);
-    int prevModelSize = prevPair->second.modelSize;
-    int lowerBoundModelSize = lowerBAfterInserts->second.modelSize;
-    ASSERT_EQ(2, lowerBoundModelSize);
-    ASSERT_EQ(3, prevModelSize);
-    ASSERT_EQ(1, firstPair->second.modelSize);
+    ASSERT_EQ(lowerBeforeInserts, testMap.penaltyModelMap.end()); //Testing that this is indeed the case. 
+
+    ASSERT_EQ(prev(lowerBeforeInserts)->first, 2.0); //Used std::iterator's prev() to revert to the current entry from lower_bound iterator in O(1) time
+    testMap.insert(5.0, model2Seg); //Insert a new model with two segments at penalty 5.0
+    testMap.displayMap(); 
+    auto lowerBAfterInserts = testMap.penaltyModelMap.lower_bound(3.0); //Created a new iterator to the new value returned by lower_bound, iterator points to 5.0 entry.
+    ASSERT_EQ(lowerBAfterInserts->first, 5.0); //This lower bound call does indeed return the model stored with key 5.0. THIS IS AFTER THE QUERY, I WANT WHAT IS BEFORE AS WELL.
+    auto prevPair = prev(lowerBAfterInserts); //To get what is before the query of 3.0, I must use the prev function on the iterator given by lower_bound
+    auto firstPair = prev(lowerBAfterInserts, 2); //To get to the firstPair, I call prev with parameter 2 as well, to get an iterator to the key 0.0, or two keys before. 
+    ASSERT_EQ(prevPair->first, 2.0); //Assert that the pair before the lower_bound call is the model we inserted with penalty key 2.0. (the model before).
+    ASSERT_EQ(firstPair->first, 0.0); //Assert that the pair two steps before the lower_bound iterator is the first model (key 0).
+    //All asserts pass 6/16/20.
   }
 
    TEST(InsertTests, DISABLED_testDuplicatePenalty){
@@ -106,7 +106,7 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
    
    }
 
-   TEST(InsertTests, testPreviousModelIterator){
+   TEST(DISABLED_InsertTests, testPreviousModelIterator){
      ModelSelectionMap testMap = ModelSelectionMap();
      double expectedPrevPen = 0.0;
      ASSERT_EQ(expectedPrevPen, testMap.prevInsertedPair->first);
@@ -163,7 +163,7 @@ TEST(ModelCreationTests, DISABLED_modelLossTestPos){
 
 
 //Test PenaltyModelPair insertion based on panel 2 (Middle with three models. Low start loss for #3, 2 not considered.)
-TEST(DISABLED_InsertTests, testInsertMiddlePanel){
+TEST(InsertTests, testInsertMiddlePanel){
     ModelSelectionMap testMap = ModelSelectionMap(testMap.STD_MODEL_CAP);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -191,6 +191,7 @@ TEST(DISABLED_InsertTests, testInsertMiddlePanel){
 
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
+//TODO complete this test after the left and middle panel tests pass.
 TEST(DISABLED_InsertTests, testInsertRightPanel){
     ModelSelectionMap testMap = ModelSelectionMap(testMap.STD_MODEL_CAP);
     Model model1Seg = Model(1, 7.0);
@@ -205,7 +206,7 @@ TEST(DISABLED_InsertTests, testInsertRightPanel){
 
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(DISABLED_InsertTests, insertSameModelSize){
+TEST(InsertTests, insertSameModelSize){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, model5Seg);
@@ -215,7 +216,7 @@ TEST(DISABLED_InsertTests, insertSameModelSize){
     testMap.insert(3.0, model5Seg);
     testMinimize(testMap.minimize(3.0), 5, true, 3.0);
     
-    //This test passes under the current insert implementation, but the memory result is not constant. 
+    //This test passes under the current insert implementation, but the memory result is not constant. TODO: Add expanded duplicate key logic to insert!
     testMap.displayMap(); 
 
    }

--- a/src/PartialModelSelectionMain.hpp
+++ b/src/PartialModelSelectionMain.hpp
@@ -1,3 +1,0 @@
-#include "PartialModelSelection.hpp"
-//void testMinimize(ModelSelectionMap testMap, double lowModelSize, double highModelSize, double penaltyQuery);
-//void testGetPen(ModelSelectionMap testMap, double expectedPenalty);


### PR DESCRIPTION
Please reference the testLowerBoundInsertion commit for a detailed explanation of that test and how it relates to the issue I made. I wanted to see how I could access the previous key as well as the key after a potential penalty query so that I could use the information within them to implement minimize as well as proper insertion logic. 

This pull request contains commits I made that allow minimize and insertions to handle many unsure results in the insertLeftPanel case. Not completely finished developing them to pass that test, but I am getting very close. 

Insert middle panel passes about half of its tests, and I am waiting to start testing the test for the right panel of our figure 1 until I can get the left and middle panels to give me what I want for minimize and insertions.  