### PR TITLE
Additional features, most of right panel insertions work with penalized insertion. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ settings.json
 partialSelect
 suppressions.txt
 .vscode/
+.Rproj.user

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # PartialSetModelSelection
 Implementation of an optimal model selection function using input from a partial set of segmentation models.
+
+
+Goal is to expand on this [previous linear time algorithm](https://arxiv.org/abs/2003.02808) and complete breakpoint path computation in O(lgn) time using std::map as the core data structure. 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Implementation of an optimal model selection function using input from a partial set of segmentation models.
 
 
-Goal is to expand on this [previous linear time algorithm](https://arxiv.org/abs/2003.02808) and complete breakpoint path computation in O(lgn) time using std::map as the core data structure. 
+Goal is to expand on this [previous linear time algorithm](https://arxiv.org/abs/2003.02808) and complete breakpoint path computation in O(lgn) time using std::map as the core data structure. This new algorithm will be more flexible than the previous one, as we can now select and add to a partial set of segmentation models to consider, rather than all models ε {1..N}. 

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -13,7 +13,7 @@
 /*MODEL SELECTION MAP IMPLEMENTATIONS*/
 ModelSelectionMap::ModelSelectionMap(double maxModels) : modelSizeCap(maxModels) {   
    //Set a starting point to be stored at penalty 0 using a placeholder pair to return default results. 
-   Model startingModel = Model(1,-1); //Used -1 as a default starting loss, will probably refactor.
+   Model startingModel = Model(1,1);
    startingModel.minimizeResult = MinimizeResult(1,false);
    startingModel.optimalPenalties = std::make_pair(0,0);
    startingModel.modelSizeAfter = 1;
@@ -178,9 +178,16 @@ bool ModelSelectionMap::hasModelsInserted(){return insertedModels > 0;}
 //General Utilities used in ModelSelectionMap
 //Takes in an insertion result and returns the iterator to the insertion if it is valid. 
 std::map<double, Model>::iterator ModelSelectionMap::validateInsert(std::pair<std::map<double, Model>::iterator, bool> insertResult){
-    //Get existing pair for error code
-    //The result from insert is: std::pair<iterator,bool> where the bool represents the success/failure of insertion.
+    double candidatePenalty = insertResult.first->first;
+    //If the candidate penalty for insertion is less than the min value of 0, throw an error.
+    if(candidatePenalty < 0){
+       throw std::out_of_range("[ ERROR ] Cannot insert with penalty = " + std::to_string(candidatePenalty) +
+         " because it is less than 0!");
+    }
+
+
     if(!insertResult.second){
+     //Get existing pair for error code
      auto existingKey = penaltyModelMap.find(insertResult.first->first);
      int existingModelSize = existingKey->second.modelSize;
      int attemptedInsertSize = insertResult.first->first;

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -32,6 +32,7 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
    std::map<double,Model>::iterator nextPair = penaltyModelMap.lower_bound(newPenalty);
    std::map<double, Model>::iterator prevPair = prev(nextPair);
+   std::vector<double>::iterator cachedPenalty = std::find(newPenalties.begin(), newPenalties.end(), newPenalty);
    //By default, we have the same model size after us, unless it is updated below.
    newPair.second.modelSizeAfter = modelSize;
    try{
@@ -61,6 +62,12 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
       }
       //Update the last inserted pair iterator
       lastInsertedPair = penaltyModelMap.find(newPair.first);
+      //If the penalty was already suggested in the getNextPenalty list, remove it. TODO: REFACTOR OR TALK ABOUT O(N) complexity here!
+     /* if(cachedPenalty != newPenalties.end()){
+         std::cout<< "TRYING TO REMOVE PENALTY: " << newPenalty << "\n";
+         newPenalties.erase(cachedPenalty);
+      }*/
+         
    }
    catch(std::logic_error errorMessage) {
       //update the placeholder on value instead of returning an error message if penalty is 0.

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -29,6 +29,8 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
    std::map<double,Model>::iterator nextPair = penaltyModelMap.lower_bound(newPenalty);
    std::map<double, Model>::iterator prevPair = prev(nextPair);
+   //By default, we have the same model size after us, unless it is updated below.
+   newPair.second.modelSizeAfter = modelSize;
    try{
       auto insertResult = penaltyModelMap.insert(newPair);
       validateInsert(insertResult); //Will throw a logic_error exception if duplicate keys are found, handled below.
@@ -85,10 +87,10 @@ void ModelSelectionMap::insert(int modelSize, double loss){
       insert(candidateBkpt, modelSize, loss); //This will update the last inserted pair, so we need to use the variable above
       lastInsertedPair->second.modelSizeAfter = lastModelSize;
    }
-   //If there is nothing in there, add at penalty 0
+   //If there is nothing in there, add at penalty INFINITY as we don't know anything about other models to chain to. 
    else{
       //Call the insert function and update the 0.0 placeholder to reflect insertion
-      insert(0.0, modelSize, loss);
+      insert(INFINITY, modelSize, loss);
       penaltyModelMap.begin()->second.isPlaceHolder = true;
    }
 }
@@ -144,9 +146,9 @@ double findBreakpoint(Model firstModel, Model secondModel){
 //Method to display the currently stored pairs in the map. 
 void ModelSelectionMap::displayMap() {
   std::cout <<  "\nCurrent Map Display\n" << "#######################\n";
-  std::cout << "Penalty          ModelSize          ModelSizeAfter             isPlaceHolder?\n"; 
-  for (std::map<double,Model>::iterator it=penaltyModelMap.begin(); it!=penaltyModelMap.end(); ++it)
-      std::cout << it->first << "      =>           " << it->second.modelSize << "      =>           "  << it->second.modelSizeAfter << it->second.isPlaceHolder << '\n';
+  std::cout << "Penalty          ModelSize          ModelSizeAfter\n"; 
+  for (std::map<double,Model>::iterator it=penaltyModelMap.begin(); it!=penaltyModelMap.end(); ++it) 
+      std::cout << it->first << "      =>           " << it->second.modelSize << "      =>           "  << it->second.modelSizeAfter << '\n';
 
    std::cout << " \n";
  }

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -48,14 +48,12 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
       if(nextPair->first != 0.0){
          prevPair->second.modelSizeAfter = newModel.modelSize;
          if(prevPair->second.isPlaceHolder) prevPair->second.modelSize = modelSize;
-         if(newModel.modelSize != prevPair->second.modelSize)
-            newPenalties.push_back(findBreakpoint(newModel, prevPair->second));
+         addBreakpoint(newModel, prevPair->second);
       }
       //UPDATE MODELS AFTER US
       if(nextPair != penaltyModelMap.end()){
          newPair.second.modelSizeAfter = nextPair->second.modelSize;
-         if(newModel.modelSize != prevPair->second.modelSize)
-            newPenalties.push_back(findBreakpoint(newModel, prevPair->second)); 
+         addBreakpoint(newModel, nextPair->second); 
       }
       //If there is nothing different after us, set the after value to the current value. 
       else{
@@ -139,6 +137,11 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
        }  
     } 
     return queryResult;
+}
+
+void ModelSelectionMap::addBreakpoint(Model firstModel, Model secondModel){
+   if(firstModel.modelSize != secondModel.modelSize)
+      newPenalties.push_back(findBreakpoint(firstModel, secondModel)); //Make this a function.
 }
 
 std::vector<double> ModelSelectionMap::getNewPenaltyList(){

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -27,7 +27,7 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
    //Insert into ourpenaltyModelPair map in the ModelSelectionMap if the newPenalty is not within it.
    Model newModel = Model(modelSize, loss);
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
-   auto nextPair = penaltyModelMap.lower_bound(newPenalty);
+   std::map<double,Model>::iterator nextPair = penaltyModelMap.lower_bound(newPenalty);
    std::map<double, Model>::iterator prevPair = prev(nextPair);
    try{
       auto insertResult = penaltyModelMap.insert(newPair);
@@ -66,7 +66,6 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
          firstKey->second.isPlaceHolder = false;
          //As we official solved a model for 0, increment the inserted models as it is no longer a placeholder. 
          insertedModels++;
-
          //Update the last inserted pair iterator
          lastInsertedPair = penaltyModelMap.find(newPair.first);
       }  
@@ -90,6 +89,7 @@ void ModelSelectionMap::insert(int modelSize, double loss){
    else{
       //Call the insert function and update the 0.0 placeholder to reflect insertion
       insert(0.0, modelSize, loss);
+      penaltyModelMap.begin()->second.isPlaceHolder = true;
    }
 }
 
@@ -144,9 +144,9 @@ double findBreakpoint(Model firstModel, Model secondModel){
 //Method to display the currently stored pairs in the map. 
 void ModelSelectionMap::displayMap() {
   std::cout <<  "\nCurrent Map Display\n" << "#######################\n";
-  std::cout << "Penalty          ModelSize          ModelSizeAfter\n"; 
+  std::cout << "Penalty          ModelSize          ModelSizeAfter             isPlaceHolder?\n"; 
   for (std::map<double,Model>::iterator it=penaltyModelMap.begin(); it!=penaltyModelMap.end(); ++it)
-      std::cout << it->first << "      =>           " << it->second.modelSize << "      =>           "  << it->second.modelSizeAfter << '\n';
+      std::cout << it->first << "      =>           " << it->second.modelSize << "      =>           "  << it->second.modelSizeAfter << it->second.isPlaceHolder << '\n';
 
    std::cout << " \n";
  }

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -137,7 +137,8 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
 
 std::vector<double> ModelSelectionMap::getNewPenaltyList(){
   //Return the list of potential penalties to query next.   
-   return newPenalties; 
+   return newPenalties;
+}
 
 double findBreakpoint(Model firstModel, Model secondModel){
    return (secondModel.loss - firstModel.loss) / (firstModel.modelSize - secondModel.modelSize);

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <iterator>
 #include <algorithm>
+
+
 //Local includes
 #include "PartialModelSelection.hpp"
 
@@ -158,35 +160,7 @@ std::vector<double> ModelSelectionMap::getNewPenaltyList(){
   //Return the list of potential penalties to query next.   
    return newPenalties;
 }
-
-double findBreakpoint(Model firstModel, Model secondModel){
-   return (secondModel.loss - firstModel.loss) / (firstModel.modelSize - secondModel.modelSize);
-}
-
-double findCost( double penalty, int modelSize, double loss){
-   return penalty*modelSize + loss;
-}
-
-//Method to display the currently stored pairs in the map. 
-void ModelSelectionMap::displayMap() {
-  std::cout <<  "\nCurrent Map Display\n" << "#######################\n";
-  std::cout << "Penalty          ModelSize          ModelSizeAfter\n"; 
-  for (std::map<double,Model>::iterator it=penaltyModelMap.begin(); it!=penaltyModelMap.end(); ++it) 
-      std::cout << it->first << "      =>           " << it->second.modelSize << "      =>           "  << it->second.modelSizeAfter << '\n';
-
-   std::cout << " \n";
- }
-void ModelSelectionMap::displayPenList(){
-    std::cout << "Candidate penalties in newPenList: " << "\n";
-    for (std::vector<double>::iterator it=newPenalties.begin(); it!=newPenalties.end(); ++it)
-      std::cout << *it << "   ";
-   std::cout << " \n";
- }
-  
-bool ModelSelectionMap::hasModelsInserted(){return insertedModels > 0;}
-
-//General Utilities used in ModelSelectionMap
-//Takes in an insertion result and returns the iterator to the insertion if it is valid. 
+ 
 std::map<double, Model>::iterator ModelSelectionMap::validateInsert(PenaltyModelPair newPair, std::map<double, Model>::iterator nextPair){
     double candidatePenalty = newPair.first;
     auto prevPair = prev(nextPair);
@@ -209,18 +183,41 @@ std::map<double, Model>::iterator ModelSelectionMap::validateInsert(PenaltyModel
     }
 
     //Check if the new penalty is redundant, as it is within an already established range. 
-    if(prevPair->second.modelSize == attemptedInsertSize && nextPair->second.modelSize == attemptedInsertSize){
+    if(!prevPair->second.isPlaceHolder && prevPair->second.modelSize == attemptedInsertSize 
+               && nextPair->second.modelSize == attemptedInsertSize){
        throw std::logic_error("[ ERROR ] Cannot insert at penalty = " + std::to_string(candidatePenalty) 
          + " because it lies within the solved range of [" + std::to_string(prevPair->first) 
               + "," + std::to_string(nextPair->first) + "].\n");
     }
-
     //TODO: Add condition to widen the range on an insertion. 
-    
     return nextPair;
 }
 
+//General Utilities used in ModelSelectionMap
+double findBreakpoint(Model firstModel, Model secondModel){
+   return (secondModel.loss - firstModel.loss) / (firstModel.modelSize - secondModel.modelSize);
+}
 
+double findCost( double penalty, int modelSize, double loss){return penalty*modelSize + loss;}
+
+bool ModelSelectionMap::hasModelsInserted(){return insertedModels > 0;}
+
+//DISPLAY METHODS
+void ModelSelectionMap::displayMap() {
+  std::cout <<  "\nCurrent Map Display\n" << "#######################\n";
+  std::cout << "Penalty          ModelSize          ModelSizeAfter\n"; 
+  for (std::map<double,Model>::iterator it=penaltyModelMap.begin(); it!=penaltyModelMap.end(); ++it) 
+      std::cout << it->first << "      =>           " << it->second.modelSize << "      =>           "  << it->second.modelSizeAfter << '\n';
+
+   std::cout << " \n";
+ }
+void ModelSelectionMap::displayPenList(){
+    std::cout << "Candidate penalties in newPenList: " << "\n";
+    for (std::vector<double>::iterator it=newPenalties.begin(); it!=newPenalties.end(); ++it)
+      std::cout << *it << "   ";
+   std::cout << " \n";
+ }
+  
 //MinimizeResult Method Implementations
 //Initialization constructor for a minimizeResult based on passed args from the minimize method. 
 MinimizeResult::MinimizeResult(int inputModelSize, bool inputCertainty) : modelSize(inputModelSize), certain(inputCertainty){}

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -112,10 +112,10 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
    bool isCertain = false;
     //If we found an inserted pair that lies on the queried penalty itself
     if(indexPenalty == penaltyQuery) {
-       //Make a query result to return using the second element of a testedPair, Model. Get its modelSize.
-       if(!indexModel.isPlaceHolder)
+      //Make a query result to return using the second element of a testedPair, Model. Get its modelSize.
+      if(!indexModel.isPlaceHolder)
          isCertain = true; 
-       queryResult = MinimizeResult(indexModel.modelSize, isCertain);
+      queryResult = MinimizeResult(indexModel.modelSize, isCertain);
     }
     //If we find a result that lies after an inserted 1 segment model, it should 1 for sure.  End of map clause.
     else if(indexPair == penaltyModelMap.end() && prevModel.modelSize == 1 && !prevModel.isPlaceHolder){
@@ -141,6 +141,10 @@ std::vector<double> ModelSelectionMap::getNewPenaltyList(){
 
 double findBreakpoint(Model firstModel, Model secondModel){
    return (secondModel.loss - firstModel.loss) / (firstModel.modelSize - secondModel.modelSize);
+}
+
+double findCost( double penalty, int modelSize, double loss){
+   return penalty*modelSize + loss;
 }
 
 //Method to display the currently stored pairs in the map. 

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -14,6 +14,8 @@
 ModelSelectionMap::ModelSelectionMap(double maxModels) : modelSizeCap(maxModels) {   
    //Set a starting point to be stored at penalty 0 using a placeholder pair to return default results. 
    Model startingModel = Model(1,-1); //Used -1 as a default starting loss, will probably refactor.
+   startingModel.minimizeResult = MinimizeResult(1,false);
+   startingModel.optimalPenalties = std::make_pair(0,0);
    startingModel.modelSizeAfter = 1;
    startingModel.isPlaceHolder = true;
    PenaltyModelPair startingPair = PenaltyModelPair(0.0, startingModel);
@@ -21,6 +23,7 @@ ModelSelectionMap::ModelSelectionMap(double maxModels) : modelSizeCap(maxModels)
    lastInsertedPair = penaltyModelMap.end(); //Set the previous pair to the end of the map as placeholder does not count. 
    insertedModels = 0; //This starts at 0 as we exclude the beginning placeholder. 
    newPenalties.push_back(0.0);
+
 }
 
 void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -112,6 +112,7 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
    Model prevModel = prevPair->second;
    bool isCertain = false;
 
+    
     //If we found an inserted pair that lies on the queried penalty itself
     if(indexPenalty == penaltyQuery && !indexModel.isPlaceHolder) {
        //Make a query result to return using the second element of a testedPair, Model. Get its modelSize.
@@ -125,6 +126,9 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
     } 
     //If we find a result that is not after 1, nor is it a solved point for sure. TODO: updated logic here with breakpoints and model cap bounds.
     else{
+       if(indexModel.isPlaceHolder)
+         return MinimizeResult(indexModel.modelSize, isCertain);
+
        //If we are below the final model size alloted, then the result is certain. 
        if(prevModel.modelSize == modelSizeCap){
           isCertain = true;

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -48,23 +48,19 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
       if(nextPair->first != 0.0){
          prevPair->second.modelSizeAfter = newModel.modelSize;
          if(prevPair->second.isPlaceHolder) prevPair->second.modelSize = modelSize;
-         
-            newPenalties.push_back(findBreakpoint(newModel, prevPair->second)); //Check here is breaking things, need to fix. 
-         
-         
+         if(newModel.modelSize != prevPair->second.modelSize)
+            newPenalties.push_back(findBreakpoint(newModel, prevPair->second));
       }
       //UPDATE MODELS AFTER US
       if(nextPair != penaltyModelMap.end()){
          newPair.second.modelSizeAfter = nextPair->second.modelSize;
-         newPenalties.push_back(findBreakpoint(newModel, nextPair->second));
+         if(newModel.modelSize != prevPair->second.modelSize)
+            newPenalties.push_back(findBreakpoint(newModel, prevPair->second)); 
       }
-         
       //If there is nothing different after us, set the after value to the current value. 
       else{
          newPair.second.modelSizeAfter = newModel.modelSize;
       }
-      
-
       //Update the last inserted pair iterator
       lastInsertedPair = penaltyModelMap.find(newPair.first);
    }

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -13,7 +13,6 @@
 /*MODEL SELECTION MAP IMPLEMENTATIONS*/
 ModelSelectionMap::ModelSelectionMap(double maxModels) : modelSizeCap(maxModels) {   
    //Set a starting point to be stored at penalty 0 using a placeholder pair to return default results. 
-
    Model startingModel = Model(1,-1); //Used -1 as a default starting loss, will probably refactor.
    startingModel.modelSizeAfter = 1;
    startingModel.isPlaceHolder = true;
@@ -30,7 +29,6 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
    auto nextPair = penaltyModelMap.lower_bound(newPenalty);
    std::map<double, Model>::iterator prevPair = prev(nextPair);
-
    try{
       auto insertResult = penaltyModelMap.insert(newPair);
       validateInsert(insertResult); //Will throw a logic_error exception if duplicate keys are found, handled below.
@@ -98,8 +96,7 @@ void ModelSelectionMap::insert(int modelSize, double loss){
 void ModelSelectionMap::remove(std::map<double, Model>::iterator toRemove){
    //Remove from map
    penaltyModelMap.erase(toRemove);
-   //Update other entries to reflect new path (May need to be before removal
-   
+   //Update other entries to reflect new path (May need to be before removal 
 }
 
 MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
@@ -153,7 +150,7 @@ void ModelSelectionMap::displayMap() {
 
    std::cout << " \n";
  }
- void ModelSelectionMap::displayPenList(){
+void ModelSelectionMap::displayPenList(){
     std::cout << "Candidate penalties in newPenList: " << "\n";
     for (std::vector<double>::iterator it=newPenalties.begin(); it!=newPenalties.end(); ++it)
       std::cout << *it << "   ";

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -111,12 +111,11 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
    auto prevPair = prev(indexPair);
    Model prevModel = prevPair->second;
    bool isCertain = false;
-
-    
     //If we found an inserted pair that lies on the queried penalty itself
-    if(indexPenalty == penaltyQuery && !indexModel.isPlaceHolder) {
+    if(indexPenalty == penaltyQuery) {
        //Make a query result to return using the second element of a testedPair, Model. Get its modelSize.
-       isCertain = true; 
+       if(!indexModel.isPlaceHolder)
+         isCertain = true; 
        queryResult = MinimizeResult(indexModel.modelSize, isCertain);
     }
     //If we find a result that lies after an inserted 1 segment model, it should 1 for sure.  End of map clause.
@@ -126,13 +125,10 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
     } 
     //If we find a result that is not after 1, nor is it a solved point for sure. TODO: updated logic here with breakpoints and model cap bounds.
     else{
-       if(indexModel.isPlaceHolder)
-         return MinimizeResult(indexModel.modelSize, isCertain);
-
        //If we are below the final model size alloted, then the result is certain. 
        if(prevModel.modelSize == modelSizeCap){
           isCertain = true;
-       } 
+       }
        queryResult = MinimizeResult(prevModel.modelSize, isCertain);
     } 
     //Return the processed query.

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <map>
 #include <stdexcept>
-#include <vector>
+#include <list>
 #include <math.h>
 #include <string>
 #include <iterator>
@@ -32,7 +32,6 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
    PenaltyModelPair newPair = PenaltyModelPair(newPenalty, newModel);
    std::map<double,Model>::iterator nextPair = penaltyModelMap.lower_bound(newPenalty);
    std::map<double, Model>::iterator prevPair = prev(nextPair);
-   std::vector<double>::iterator cachedPenalty = std::find(newPenaltyList.begin(), newPenaltyList.end(), newPenalty);
    //By default, we have the same model size after us, unless it is updated below.
    newPair.second.modelSizeAfter = modelSize;
    try{
@@ -184,7 +183,11 @@ std::map<double, Model>::iterator ModelSelectionMap::validateInsert(PenaltyModel
 }
 
 //General Utilities used in testing and in the ModelSelectionMap class. 
-std::vector<double> ModelSelectionMap::getNewPenaltyList(){return newPenaltyList;}
+double ModelSelectionMap::getNewPenalty(){
+   double newPenalty = newPenaltyList.front();
+   newPenaltyList.pop_front();
+   return newPenalty;
+}
 
 bool ModelSelectionMap::hasModelsInserted(){return insertedModels > 0;}
 
@@ -199,7 +202,7 @@ void ModelSelectionMap::displayMap() {
  }
 void ModelSelectionMap::displayPenList(){
     std::cout << "Candidate penalties in newPenList: " << "\n";
-    for (std::vector<double>::iterator it=newPenaltyList.begin(); it!=newPenaltyList.end(); ++it)
+    for (std::list<double>::iterator it=newPenaltyList.begin(); it!=newPenaltyList.end(); ++it)
       std::cout << *it << "   ";
    std::cout << " \n";
  }

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -36,7 +36,7 @@ void ModelSelectionMap::insert(double newPenalty, int modelSize, double loss){
       validateInsert(insertResult); //Will throw a logic_error exception if duplicate keys are found, handled below.
       //Update initial placeholder pair       
       if(insertedModels == 0){
-         std::map<double, Model>::iterator placeHolder = penaltyModelMap.begin();
+         auto placeHolder = penaltyModelMap.begin();
          placeHolder->second.modelSize = newModel.modelSize;
       } 
       insertedModels++;
@@ -91,7 +91,6 @@ void ModelSelectionMap::insert(int modelSize, double loss){
    else{
       //Call the insert function and update the 0.0 placeholder to reflect insertion
       insert(INFINITY, modelSize, loss);
-      penaltyModelMap.begin()->second.isPlaceHolder = true;
    }
 }
 
@@ -128,9 +127,8 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
        if(prevModel.modelSize == modelSizeCap){
           isCertain = true;
        }
-       queryResult = MinimizeResult(prevModel.modelSize, isCertain);
+       queryResult = MinimizeResult(prevModel.modelSize, isCertain); //GDB reveals this is called with prevModel.modelSize when it shouldn't be.nb
     } 
-    //Return the processed query.
     return queryResult;
 }
 

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -127,7 +127,7 @@ MinimizeResult ModelSelectionMap::minimize(double penaltyQuery){
        if(prevModel.modelSize == modelSizeCap){
           isCertain = true;
        }
-       queryResult = MinimizeResult(prevModel.modelSize, isCertain); //GDB reveals this is called with prevModel.modelSize when it shouldn't be.nb
+       queryResult = MinimizeResult(prevModel.modelSize, isCertain); //GDB reveals this is called with prevModel.modelSize when it shouldn't be.nb   
     } 
     return queryResult;
 }

--- a/src/PartialModelSelection.cpp
+++ b/src/PartialModelSelection.cpp
@@ -15,7 +15,6 @@
 ModelSelectionMap::ModelSelectionMap(double maxModels) : modelSizeCap(maxModels) {   
    //Set a starting point to be stored at penalty 0 using a placeholder pair to return default results. 
    Model startingModel = Model(1,1);
-   startingModel.minimizeResult = MinimizeResult(1,false);
    startingModel.optimalPenalties = std::make_pair(0,0);
    startingModel.modelSizeAfter = 1;
    startingModel.isPlaceHolder = true;

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -96,19 +96,7 @@ public:
     Note: none
     */
     std::vector<double> getNewPenaltyList();
-
-    Function name: Solver
-    Algorithm: Binary segmentation? 
-
-    Precondition: for correct operation, the passed penalty is a valid
-    float value.
-    Postcondition:
-    Exceptions: none yet. 
-    Note: none
-    */
-    std::pair<int, int> solver(double penalty);
-
-
+    
     /*
     Function name: Minimize
     Algorithm: Acquires a penalty value lambda and returns a minimization result consisting of:

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <map>
 #include <vector>
+#include <list>
 
 //Struct to embody Model,Boolean pairs for model selection path records.
 struct MinimizeResult {
@@ -48,7 +49,7 @@ public:
     std::map<double, Model> penaltyModelMap; 
     
     //List to hold new candidate penalties and breakpoints to give new information from minimize.
-    std::vector<double> newPenaltyList;
+    std::list<double> newPenaltyList;
     
     //Method headers
     //Default value of INFINITY for no passed cap
@@ -98,7 +99,7 @@ public:
 
 
     /*
-    Function name: getNewPenaltyList
+    Function name: getNewPenalty
     Algorithm: O(1) or O(log N) query of a penalty value that will result in new information. 
     Precondition: for correct operation, the passed penaltyQuery is a valid
     float value.
@@ -108,7 +109,7 @@ public:
     Exceptions: none?
     Note: none
     */
-    std::vector<double> getNewPenaltyList();
+    double getNewPenalty();
     
     /*
     Function name: Minimize

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 struct Model {
-    Model(int modelSize, double loss) : modelSize(modelSize), loss(loss) {}
+    Model(int modelSize, double loss) : modelSize(modelSize), loss(loss), isPlaceHolder(false) {}
     //Number of segments (k-value)
     int modelSize = 0;
     //Loss associated with the given model 
@@ -12,8 +12,6 @@ struct Model {
     int modelSizeAfter; //Used for next Model (the after flag in psuedocode)
     bool isSameAfter; //Used to determine if the current modelSize is the same as the predicted next.
     bool isPlaceHolder; //Used to determine if the key at 0 is the initial key we insert.
-    //Range of penalties for which this model is optimal.
-    std::pair<double,double> optimalPenaltyRange;
 };
 
 

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -12,6 +12,7 @@ struct MinimizeResult {
 };
 
 struct Model {
+    //Create a model if it has valid modelSize and loss values given. 
     Model(int inputSize, double inputLoss) : modelSize(inputSize), loss(loss), isPlaceHolder(false) {
         if(inputSize >= 0 && inputLoss >= 0){
             modelSize = inputSize;
@@ -26,10 +27,12 @@ struct Model {
     int modelSize = 0;
     //Loss associated with the given model 
     double loss = 0.0;
-    int modelSizeAfter; //Used for next Model (the after flag in psuedocode)
-    MinimizeResult minimizeResult;
-    bool isPlaceHolder; //Used to determine if the key at 0 is the initial key we insert.
-    std::pair<double,double> optimalPenalties; //Used to filter out unnecessary penalties within optimal range. 
+    //Used to store the next model size, changes from this.modelSize if there are two models at a breakpoint
+    int modelSizeAfter; 
+    //Used to determine if the key at 0 is the initial key we insert.
+    bool isPlaceHolder; 
+    //Used to filter out unnecessary penalties within optimal range. (NOT YET USED)
+    std::pair<double,double> optimalPenalties;  
 };
 
 //struct penaltyModelPair may be better here for more readability
@@ -90,7 +93,6 @@ public:
     Precondition: The model is formatted correctly and the
     penalty is a valid double.
     Postcondition: Removes the model from the data structure.
-    Returns the removed pair.
     Exceptions: correctly and appropriately (without program failure)
         responds to and reports failure to insert the model.
     Note: none
@@ -101,11 +103,8 @@ public:
     /*
     Function name: getNewPenalty
     Algorithm: O(1) or O(log N) query of a penalty value that will result in new information. 
-    Precondition: for correct operation, the passed penaltyQuery is a valid
-    float value.
-    Postcondition: in correct operation, computes what model is optimal
-    for the passed penaltyQuery, and gives a boolean signifying its accuracy.
-    Both these values are passed back as a struct.
+    Precondition: None
+    Postcondition: Returns a double value 
     Exceptions: none?
     Note: none
     */
@@ -132,7 +131,7 @@ public:
     //Simply displays the current map structure
     void displayMap();
 
-    //Adds a new breakpoint to the newPenalties list for later consideration. 
+    //Adds a new breakpoint penalty to the back of the newPenalties list for later consideration. 
     void addBreakpoint(Model firstModel, Model secondModel);
 
     //Displays the list of penalties currently stored to recommend for a new query in getNewPenalty.

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -17,6 +17,13 @@ struct Model {
 };
 
 
+struct Breakpoint {
+    double penalty;
+    std::pair<int, int> optimalModelSizes;
+
+};
+
+
 //Struct to embody Model,Boolean pairs for model selection path records.
 struct MinimizeResult {
     MinimizeResult(int modelSize = 1, bool certain = false);

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -3,6 +3,18 @@
 #include <map>
 #include <vector>
 
+struct Breakpoint {
+    double penalty;
+    std::pair<int, int> optimalModelSizes;
+};
+
+//Struct to embody Model,Boolean pairs for model selection path records.
+struct MinimizeResult {
+    MinimizeResult(int modelSize = 1, bool certain = false);
+    bool certain;
+    int modelSize;
+};
+
 struct Model {
     Model(int modelSize, double loss) : modelSize(modelSize), loss(loss), isPlaceHolder(false) {}
     //Number of segments (k-value)
@@ -14,22 +26,6 @@ struct Model {
     bool isPlaceHolder; //Used to determine if the key at 0 is the initial key we insert.
     std::pair<double,double> optimalPenalties; //Used to filter out unnecessary penalties within optimal range. 
 };
-
-
-struct Breakpoint {
-    double penalty;
-    std::pair<int, int> optimalModelSizes;
-
-};
-
-
-//Struct to embody Model,Boolean pairs for model selection path records.
-struct MinimizeResult {
-    MinimizeResult(int modelSize = 1, bool certain = false);
-    bool certain;
-    int modelSize;
-};
-
 
 //struct penaltyModelPair may be better here for more readability
 using PenaltyModelPair = std::pair<double, Model>;

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -16,7 +16,16 @@ struct MinimizeResult {
 };
 
 struct Model {
-    Model(int modelSize, double loss) : modelSize(modelSize), loss(loss), isPlaceHolder(false) {}
+    Model(int inputSize, double inputLoss) : modelSize(inputSize), loss(loss), isPlaceHolder(false) {
+        if(inputSize >= 0 && inputLoss >= 0){
+            modelSize = inputSize;
+            loss = inputLoss;
+        }
+        else{
+            throw std::out_of_range("[ ERROR ] Cannot create model with negative size or loss values! Provided model_size = " 
+            + std::to_string(inputSize) + ", loss = " + std::to_string(inputLoss) + "\n");
+        }
+    }
     //Number of segments (k-value)
     int modelSize = 0;
     //Loss associated with the given model 
@@ -122,9 +131,15 @@ public:
     void displayPenList();
 
     private:
-    //Utility function to validate an insertion, used before setting previous penaltyModel Pair inserted. 
+    /*
+    Utility function to validate an insertion to delegate it away from the main insert functions.
+    The result from std::map insert() is: std::pair<iterator,bool> where the bool represents the success/failure of insertion.
+    The function uses this bool value to ensure there is not a duplicate penalty already in the map
+    Another case to check for is an invalid penalty value. If the penalty is negative, it is not a valid penalty to insert with a model.*/ 
     std::map<double, Model>::iterator validateInsert(std::pair<std::map<double,Model>::iterator, bool> insertResult);
-    bool hasModelsInserted(); //Custom isEmpty method as we will add a initial model, nullifing built-in method.     
+
+    //Custom isEmpty method as we will add a initial model, nullifing built-in method with std::map.
+    bool hasModelsInserted();  
 };
 
 //Utility to compute a breakpoint between two models for use in other functions.

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -10,6 +10,7 @@ struct Model {
     //Loss associated with the given model 
     double loss = 0.0;
     int modelSizeAfter; //Used for next Model (the after flag in psuedocode)
+    MinimizeResult minimizeResult;
     bool isPlaceHolder; //Used to determine if the key at 0 is the initial key we insert.
     std::pair<double,double> optimalPenalties; //Used to filter out unnecessary penalties within optimal range. 
 };

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -3,11 +3,6 @@
 #include <map>
 #include <vector>
 
-struct Breakpoint {
-    double penalty;
-    std::pair<int, int> optimalModelSizes;
-};
-
 //Struct to embody Model,Boolean pairs for model selection path records.
 struct MinimizeResult {
     MinimizeResult(int modelSize = 1, bool certain = false);
@@ -41,20 +36,28 @@ using PenaltyModelPair = std::pair<double, Model>;
 
 class ModelSelectionMap {
 public:
-    int insertedModels; //This is used to determine if the map is 'empty' as the initial model inserted scews isEmpty() counts.
+    //This is used to determine if the map is 'empty' as the initial model inserted scews isEmpty() counts.
+    int insertedModels; 
+
+    //Max model size permitted to be inserted into the map. Defaults to INFINITY (no limit).
     const double modelSizeCap;
 
-    std::map<double,Model>::iterator lastInsertedPair; //Holds the previously computed breakpoint, if it exists, for use in constant time insertion. 
+    std::map<double,Model>::iterator lastInsertedPair; //Holds the previously computed breakpoint, if it exists, for use in constant time insertion.
+
     //Map struct to hold penalty and model pairings from inserts.
     std::map<double, Model> penaltyModelMap; 
-    //Vector to hold new candidate penalties and breakpoints to give new information from minimize.
-    std::vector<double> newPenalties;
+    
+    //List to hold new candidate penalties and breakpoints to give new information from minimize.
+    std::vector<double> newPenaltyList;
+    
     //Method headers
     //Default value of INFINITY for no passed cap
     ModelSelectionMap(double maxModels = INFINITY);
     /*
      Function name(s): insert
-     Algorithm: Inserts a new model into our partial set (map) data structure with a penalty modeling FPOP
+     Algorithm: Inserts a new model into our partial set (map) data structure with a penalty modeling FPOP.
+     The penalty is inserted using the provided parameter, indicating that the model created from the modelSize 
+     and loss parameters is optimal at that penalty key, for sure. 
      Precondition: The model is formatted correctly and the
         penalty is a valid double.
      Postcondition: Inserts the model into the data structure.
@@ -68,7 +71,8 @@ public:
     /*
     Function name: insert (overloaded)
     Algorithm: Inserts a new model into our partial set (map) without a penalty, modeling
-    binary segmentation and other constrained style solvers. 
+    binary segmentation and other constrained style solvers. Forms a model struct 
+    using the passed in modelSize and loss parameters. The penalty is computed using a breakpoint.
     Precondition: The model is formatted correctly and the
     penalty is a valid double.
     Postcondition: Inserts the model into the data structure.
@@ -94,7 +98,7 @@ public:
 
 
     /*
-    Function name: getNewpenaltyQuery
+    Function name: getNewPenaltyList
     Algorithm: O(1) or O(log N) query of a penalty value that will result in new information. 
     Precondition: for correct operation, the passed penaltyQuery is a valid
     float value.
@@ -122,12 +126,15 @@ public:
     MinimizeResult minimize(double penaltyQuery);
 
 
-    /*UTILITY METHODS*/
+    /*UTILITY METHODS WITHIN MODELSELECTIONMAP*/
+    
+    //Simply displays the current map structure
     void displayMap();
 
+    //Adds a new breakpoint to the newPenalties list for later consideration. 
     void addBreakpoint(Model firstModel, Model secondModel);
 
-
+    //Displays the list of penalties currently stored to recommend for a new query in getNewPenalty.
     void displayPenList();
 
     private:
@@ -141,6 +148,8 @@ public:
     //Custom isEmpty method as we will add a initial model, nullifing built-in method with std::map.
     bool hasModelsInserted();  
 };
+
+/*GENERAL COMPUTATIONS USED IN TESTS AND MAP*/
 
 //Utility to compute a breakpoint between two models for use in other functions.
 double findBreakpoint(Model firstModel, Model secondModel);

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -22,8 +22,6 @@ struct MinimizeResult {
     MinimizeResult(int modelSize = 1, bool certain = false);
     bool certain;
     int modelSize;
-    //Stores the potential models that could encompass a penalty query. Identical first and second value if certain (solved).
-    std::pair<double, double> optimalModels;
 };
 
 

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -130,6 +130,8 @@ public:
     bool hasModelsInserted(); //Custom isEmpty method as we will add a initial model, nullifing built-in method.     
 };
 
-
 //Utility to compute a breakpoint between two models for use in other functions.
 double findBreakpoint(Model firstModel, Model secondModel);
+//Computes the penalized cost of k*lambda for breakpoint comparison. 
+double findCost(double penalty, int modelSize, int loss);
+

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -136,7 +136,7 @@ public:
     The result from std::map insert() is: std::pair<iterator,bool> where the bool represents the success/failure of insertion.
     The function uses this bool value to ensure there is not a duplicate penalty already in the map
     Another case to check for is an invalid penalty value. If the penalty is negative, it is not a valid penalty to insert with a model.*/ 
-    std::map<double, Model>::iterator validateInsert(std::pair<std::map<double,Model>::iterator, bool> insertResult);
+    std::map<double, Model>::iterator validateInsert(PenaltyModelPair newPair, std::map<double,Model>::iterator nextPair);
 
     //Custom isEmpty method as we will add a initial model, nullifing built-in method with std::map.
     bool hasModelsInserted();  

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -116,7 +116,9 @@ public:
     /*UTILITY METHODS*/
     void displayMap();
 
-    
+    void addBreakpoint(Model firstModel, Model secondModel);
+
+
     void displayPenList();
 
     private:

--- a/src/PartialModelSelection.hpp
+++ b/src/PartialModelSelection.hpp
@@ -10,8 +10,8 @@ struct Model {
     //Loss associated with the given model 
     double loss = 0.0;
     int modelSizeAfter; //Used for next Model (the after flag in psuedocode)
-    bool isSameAfter; //Used to determine if the current modelSize is the same as the predicted next.
     bool isPlaceHolder; //Used to determine if the key at 0 is the initial key we insert.
+    std::pair<double,double> optimalPenalties; //Used to filter out unnecessary penalties within optimal range. 
 };
 
 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -270,7 +270,7 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(DISABLED_PanelTests, testInsertRightPanelPen){
+TEST(PanelTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -395,7 +395,7 @@ TEST(InsertTests, insertSameModelSizeInOrder){
 
 
    //Test PenaltyModelPair insertion based on panel 2 without penalties.
-TEST(InsertTests, insertSameModelSizeUnordered){
+TEST(DISABLED_InsertTests, insertSameModelSizeUnordered){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -29,13 +29,11 @@ void testMinimize(ModelSelectionMap testMap, double lowModelSize, bool expectedC
 }
 
 //Testing method to test getNextPen
-void testGetPen(ModelSelectionMap testMap, double expectedPenalty, int index = 0 ){
-    GTEST_GETPENCOUT << "Running test for getNextPenalty with parameters: " << "expectedPen: " << expectedPenalty 
-                << "; Index: " << index << " \n\n";
+void testGetPen(ModelSelectionMap testMap, std::vector<double> expectedPenList){
+    GTEST_GETPENCOUT << "Running test for getNextPenalty\n";
     std::vector<double> currentPenList = testMap.getNewPenaltyList();
     testMap.displayPenList();
-    double storedPen = currentPenList.at(index);
-    EXPECT_EQ(storedPen, expectedPenalty) << "Penalty returned by getNewPenalty differs from expected.\n"; 
+    EXPECT_EQ(currentPenList, expectedPenList) << "Penalty returned by getNewPenalty differs from expected.\n"; 
 }
 
 TEST(DISABLED_breakpointTests, testBreakFormation){
@@ -55,11 +53,13 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     Model model1segs = Model(1, 7);
     Model model2segs = Model(2, 4);
     ModelSelectionMap testMap = ModelSelectionMap();
+    std::vector<double> expectedPenalties{0, 3.0};
     testMap.insert(2,4.0);
     testMap.insert(1, 7.0);
     double breakpoint = findBreakpoint(model1segs, model2segs);
     testMap.displayPenList();
-    testGetPen(testMap, 0.0);
+
+    testGetPen(testMap, expectedPenalties);
    }
 
    TEST(DISABLED_breakpointTests, testInvalidBounds){
@@ -198,15 +198,15 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
-
+    std::vector<double> expectedPenalties{0, 3.0};
     testMinimize(testMap, 1, false, 5.0);
    
-    testGetPen(testMap, 0.0); //Iterator, getNewPenalty iterator? Should give us 0 to inf, so 0 to query.
+    testGetPen(testMap, expectedPenalties); //Iterator, getNewPenalty iterator? Should give us 0 to inf, so 0 to query.
 
     //Insert the one segment model for an incomplete path, given the model cap is 3.  
     testMap.insert(4.0, 1, 7.0); 
     //Test getNextPenalty
-    testGetPen(testMap, 0.0);
+    testGetPen(testMap, expectedPenalties);
     testMinimize(testMap, 1, true, 5.0); //This should be certain as nothing will become optimal after it has been solved for a penalty value. 
     //Mimize Query here
     testMinimize(testMap, 1, true, 4.0); //We solved this on through the insert.
@@ -224,7 +224,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMinimize(testMap, 2, true, 2.0); //These two queries return 2 for sure after we insert it at 0.0, and with the breakpoint at 3.0 computed from the loss and slope.  
     testMinimize(testMap, 2, true, 1.0);
     testMinimize(testMap, 2, true, 0.0);
-    testGetPen(testMap, 3.0, 1);
+    testGetPen(testMap, expectedPenalties);
    }
 
 
@@ -300,13 +300,15 @@ TEST(PanelTests, testInsertRightPanelPen){
     testMinimize(testMap, 2, true, 2.5);
     testMinimize(testMap, 3, true, 2.0); //Breakpoint between 3 and 2
     testMinimize(testMap, 3, true, 1.0);
+    std::cout << "MADE IT TO FINAL MINIMIZE\n";
+    testMap.displayPenList();
     testMinimize(testMap, 3, true, 0.0);
-    testGetPen(testMap, 0.0);
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
 TEST(DISABLED_PanelTests, testInsertRightPanel){
     ModelSelectionMap testMap = ModelSelectionMap();
+    std::vector<double> expectedPenalties{0, 3.0};
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
     Model model3Seg = Model(3, 2.0);
@@ -347,11 +349,12 @@ TEST(DISABLED_PanelTests, testInsertRightPanel){
     testMinimize(testMap, 3, true, 1.0); //With a cap this an easy solution. To be true. 
     testMinimize(testMap, 4, true, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
     testMap.displayMap();
-    testGetPen(testMap, 0.0);
+    testGetPen(testMap, expectedPenalties);
    }
 //Test for right panel insertion without minimize checks to fix issues with the two param inserts.
 TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
     ModelSelectionMap testMap = ModelSelectionMap();
+    std::vector<double> expectedPenalties{0, 3.0};
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
     Model model3Seg = Model(3, 2.0);
@@ -369,8 +372,7 @@ TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
     std::cout << "BREAKPOINT BETWEEN 3 and 4: " << findBreakpoint(model3Seg, model4Seg) << "\n\n"; //1
     testMap.insert(0, 4, 0.0);
     testMap.displayMap();
-    testMap.displayMap();
-    testGetPen(testMap, 0.0);
+    testGetPen(testMap, expectedPenalties);
    }
 
 //Test PenaltyModelPair insertion based on panel 2 without penalties.

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -273,7 +273,7 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(PanelTests, testInsertRightPanelPen){
+TEST(DISABLED_PanelTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -376,7 +376,7 @@ TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 without penalties.
-TEST(DISABLED_InsertTests, insertSameModelSize){
+TEST(InsertTests, insertSameModelSize){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -118,7 +118,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
    }
 
 
-TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
+  TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model2segs = Model(2, 5.0);
     Model model6segs = Model(6, 0.0);
@@ -166,7 +166,7 @@ TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
    }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(InsertTests, testInsertLeftPanel){
+ TEST(DISABLED_PanelInserts, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -189,6 +189,7 @@ TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
 
     //Insert two segment model and test again, should be complete path.  
     testMap.insert(0.0, 2, 4.0);
+    testMap.displayMap();
     testMinimize(testMap.minimize(5.0), 1, true, 5.0);
     testMinimize(testMap.minimize(4.0), 1, true, 4.0);
     testMinimize(testMap.minimize(3.0), 2, true, 3.0); //Breakpoint is at 3.0, so 2.0 and 1.0 should yield model with two segments as it was inserted with penatly 0.0
@@ -199,7 +200,7 @@ TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
 
 
 //Test PenaltyModelPair insertion based on panel 2 (Middle with three models. Low start loss for #3, 2 not considered.)
-TEST(DISABLED_InsertTests, testInsertMiddlePanel){
+TEST(DISABLED_PanelTests, testInsertMiddlePanel){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -239,7 +240,7 @@ TEST(DISABLED_InsertTests, testInsertMiddlePanel){
     testMinimize(testMap.minimize(3.5), 1, true, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
     testMinimize(testMap.minimize(3.0), 3, true, 2.0);
     testMinimize(testMap.minimize(1.0), 3, true, 1.0); //Should give us 1 or 2 for now, but the model cap is 3 so there is a chance that 2 can be overridden/not optimal.
-     testMinimize(testMap.minimize(0.0), 3, true, 0.0); 
+    testMinimize(testMap.minimize(0.0), 3, true, 0.0); 
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
@@ -262,7 +263,7 @@ TEST(DISABLED_InsertTests, testInsertRightPanelPen){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(InsertTests, testInsertRightPanel){
+TEST(DISABLED_PanelTests, testInsertRightPanel){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -331,7 +332,7 @@ TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 without penalties.
-TEST(InsertTests, DISABLED_insertSameModelSize){
+TEST(InsertTests, insertSameModelSize){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);
@@ -343,8 +344,15 @@ TEST(InsertTests, DISABLED_insertSameModelSize){
     
     //This test passes under the current insert implementation, but the memory result is not constant. TODO: Add expanded duplicate key logic to insert!
     testMap.displayMap(); 
-
    }
+
+
+TEST(InsertTests, insertLargeModelFirst){
+  ModelSelectionMap testMap = ModelSelectionMap();
+  testMap.insert(6, 1.0);
+  testMap.insert(1,5.0);
+  testMap.displayMap();
+}
 
 //Driver function for google test
 int main (int argc, char* argv[]){

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -14,15 +14,15 @@
 #define GTEST_GETPENCOUT std::cout << "[ GETPEN ] [INFO] "
 
 //Testing method to test minimize method (minimizeResults).   
-void testMinimize(ModelSelectionMap testMap, double lowModelSize, bool expectedCertainty, double penaltyQuery){
+void testMinimize(ModelSelectionMap testMap, double expectedModelSize, bool expectedCertainty, double penaltyQuery){
    //Log the test being run.
    MinimizeResult testResult = testMap.minimize(penaltyQuery);
    std::string certaintyString = "";
    expectedCertainty ? certaintyString = "true" : certaintyString = "false";
-   GTEST_MINCOUT << "Running test minimize with parameters: " << "low: " << lowModelSize << 
+   GTEST_MINCOUT << "Running test minimize with parameters: " << "ModelSize: " << expectedModelSize << 
                      "; expectedCertainty: " << certaintyString << "; penalty: " << penaltyQuery << "\n\n";
    //Check if the expected range of values is correct.
-   EXPECT_EQ(lowModelSize, testResult.modelSize) << "\nMinimize first parameter is different from expected.\n";
+   EXPECT_EQ(expectedModelSize, testResult.modelSize) << "\nMinimize first parameter is different from expected.\n";
    EXPECT_EQ(expectedCertainty, testResult.certain) << "\nMinimize certainty flag is different from expected.\n";      
 }
 
@@ -181,7 +181,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
   }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(DISABLED_PanelInserts, testInsertLeftPanel){
+ TEST(PanelInserts, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -190,7 +190,8 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     //Iterator, getNewPenalty iterator? Should give us 0 to inf, so 0 to query.
 
     //Insert the one segment model for an incomplete path, given the model cap is 3.  
-    testMap.insert(4.0, 1, 7.0); 
+    testMap.insert(4.0, 1, 7.0);
+    testMap.displayMap(); 
     //Test getNextPenalty
     testMinimize(testMap, 1, true, 5.0); //This should be certain as nothing will become optimal after it has been solved for a penalty value. 
     //Mimize Query here
@@ -202,9 +203,11 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
 
     //Insert two segment model and test again, should be complete path.  
     testMap.insert(0.0, 2, 4.0);
+    testMap.displayPenList();
     testMap.displayMap();
     testMinimize(testMap, 1, true, 5.0);
     testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 1, true, 3.5);
     testMinimize(testMap, 2, true, 3.0); //Breakpoint is at 3.0, so 2.0 and 1.0 should yield model with two segments as it was inserted with penatly 0.0 
     testMinimize(testMap, 2, true, 2.0); //These two queries return 2 for sure after we insert it at 0.0, and with the breakpoint at 3.0 computed from the loss and slope.  
     testMinimize(testMap, 2, true, 1.0);
@@ -257,7 +260,7 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(PanelTests, testInsertRightPanelPen){
+TEST(DISABLED_PanelTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -281,7 +281,7 @@ TEST(InsertTests, testInsertRightPanel){
     std::cout << "BREAKPOINT BETWEEN 1 and 2: " << findBreakpoint(model1Seg, model2Seg) << "\n"; //3.0
     testMinimize(testMap.minimize(5.0), 1, false, 5.0);
     testMinimize(testMap.minimize(4.0), 1, false, 4.0);
-    testMinimize(testMap.minimize(3.0), 1, false, 3.0); 
+    testMinimize(testMap.minimize(3.0), 2, false, 3.0); 
     testMinimize(testMap.minimize(2.0), 2, false, 2.0); //1 and two should be able to return true results after 3 is inserted. 
     testMinimize(testMap.minimize(1.0), 2, false, 1.0);
     testMinimize(testMap.minimize(0.0), 2, false, 0.0);
@@ -289,8 +289,8 @@ TEST(InsertTests, testInsertRightPanel){
     testMap.insert(3, 2.0);
     testMinimize(testMap.minimize(5.0), 1, false, 5.0);
     testMinimize(testMap.minimize(4.0), 1, false, 4.0);
-    testMinimize(testMap.minimize(3.0), 1, false, 3.0); 
-    testMinimize(testMap.minimize(2.0), 2, false, 2.0);
+    testMinimize(testMap.minimize(3.0), 2, false, 3.0); 
+    testMinimize(testMap.minimize(2.0), 3, false, 2.0);
     testMinimize(testMap.minimize(1.0), 3, false, 1.0); //With a cap this an easy solution. To be true. 
     testMinimize(testMap.minimize(0.0), 3, false, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
     testMap.displayMap();

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -162,7 +162,6 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMinimize(testMap, 6, true, 0.0);
   }
 
-
   TEST(DISABLED_InsertTests, testMultiNoParamInsertions){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model2segs = Model(2, 5.0);
@@ -180,30 +179,18 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMinimize(testMap, 6, true, 0.0);
   }
 
-
-  TEST(DISABLED_InsertTests, testModelSizeAfterUpdate){
-     ModelSelectionMap testMap = ModelSelectionMap(6);
-     testMap.insert(4.0, 2, 3.0);
-     testMap.insert(2.0, 3, 2.0);
-     testMap.insert(0.0, 5, 0.0);
-     testMap.displayMap(); 
-     //TODO: Asserts here.
-   }
-
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(DISABLED_PanelInserts, testInsertLeftPanel){
+ TEST(PanelInserts, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
     std::vector<double> expectedPenalties{0, 3.0};
     testMinimize(testMap, 1, false, 5.0);
-   
-    testGetPen(testMap, expectedPenalties); //Iterator, getNewPenalty iterator? Should give us 0 to inf, so 0 to query.
+    //Iterator, getNewPenalty iterator? Should give us 0 to inf, so 0 to query.
 
     //Insert the one segment model for an incomplete path, given the model cap is 3.  
     testMap.insert(4.0, 1, 7.0); 
     //Test getNextPenalty
-    testGetPen(testMap, expectedPenalties);
     testMinimize(testMap, 1, true, 5.0); //This should be certain as nothing will become optimal after it has been solved for a penalty value. 
     //Mimize Query here
     testMinimize(testMap, 1, true, 4.0); //We solved this on through the insert.
@@ -217,11 +204,10 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMap.displayMap();
     testMinimize(testMap, 1, true, 5.0);
     testMinimize(testMap, 1, true, 4.0);
-    testMinimize(testMap, 2, true, 3.0); //Breakpoint is at 3.0, so 2.0 and 1.0 should yield model with two segments as it was inserted with penatly 0.0
+    testMinimize(testMap, 2, true, 3.0); //Breakpoint is at 3.0, so 2.0 and 1.0 should yield model with two segments as it was inserted with penatly 0.0 
     testMinimize(testMap, 2, true, 2.0); //These two queries return 2 for sure after we insert it at 0.0, and with the breakpoint at 3.0 computed from the loss and slope.  
     testMinimize(testMap, 2, true, 1.0);
     testMinimize(testMap, 2, true, 0.0);
-    testGetPen(testMap, expectedPenalties);
    }
 
 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -326,7 +326,7 @@ TEST(InsertTests, testTwoParamBreakpoints){
     testMap.insert(3, 2.0);
     testMap.displayMap();
     std::cout << "BREAKPOINT BETWEEN 3 and 4: " << findBreakpoint(model3Seg, model4Seg) << "\n\n"; //1
-    testMap.insert(1, 4, 0.0);
+    testMap.insert(0, 4, 0.0);
     testMap.displayMap();
     testMap.displayMap();
     testGetPen(testMap, 0.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <math.h>
 #include <string>
+#include <stdexcept>
 
 //Local Includes
 #include "PartialModelSelection.hpp"
@@ -61,8 +62,35 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testGetPen(testMap, 0.0);
    }
 
+   TEST(breakpointTests, testInvalidBounds){
+     ModelSelectionMap testMap = ModelSelectionMap();     
+     try{
+       std::cout << "Running try block 1!\n";
+       Model modelWrongSegs = Model(-4, 3);
+     }
+     catch(std::out_of_range errorMessage){
+       std::cerr << errorMessage.what() << " \n";
+     }
+     try{
+       std::cout << "Running try block 2!\n";
+       Model modelWrongLoss = Model(4, -3);
+     }
+     catch(std::out_of_range errorMessage){
+       std::cerr << errorMessage.what() << " \n";
+     }
+     try{
+       std::cout << "Running try block 3!\n";
+       Model model1Seg = Model(2, 3.0);
+       testMap.insert(-2, 2, 3.0);
+     }
+     catch(std::out_of_range errorMessage){
+       std::cerr << errorMessage.what() << " \n";
+     }
+     
+   }
 
-   TEST(PenaltyPairsTests, testEmptyMinimization){
+
+   TEST(DISABLED_PenaltyPairsTests, testEmptyMinimization){
     ModelSelectionMap testMap = ModelSelectionMap();
     double expectedStart = 1;
     MinimizeResult emptyResult = testMap.minimize(4.0);
@@ -336,7 +364,7 @@ TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 without penalties.
-TEST(InsertTests, insertSameModelSize){
+TEST(DISABLED_InsertTests, insertSameModelSize){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -62,24 +62,21 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testGetPen(testMap, 0.0);
    }
 
-   TEST(breakpointTests, testInvalidBounds){
+   TEST(DISABLED_breakpointTests, testInvalidBounds){
      ModelSelectionMap testMap = ModelSelectionMap();     
      try{
-       std::cout << "Running try block 1!\n";
        Model modelWrongSegs = Model(-4, 3);
      }
      catch(std::out_of_range errorMessage){
        std::cerr << errorMessage.what() << " \n";
      }
      try{
-       std::cout << "Running try block 2!\n";
        Model modelWrongLoss = Model(4, -3);
      }
      catch(std::out_of_range errorMessage){
        std::cerr << errorMessage.what() << " \n";
      }
      try{
-       std::cout << "Running try block 3!\n";
        Model model1Seg = Model(2, 3.0);
        testMap.insert(-2, 2, 3.0);
      }
@@ -276,8 +273,7 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-//TODO complete this test after the left and middle panel tests pass.
-TEST(DISABLED_PanelTests, testInsertRightPanelPen){
+TEST(PanelTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -290,7 +286,21 @@ TEST(DISABLED_PanelTests, testInsertRightPanelPen){
     testMinimize(testMap, 1, false, 1.0);
     testMinimize(testMap, 1, false, 0.0);
     testMap.insert(2.5, 2, 4.0);
+    testMinimize(testMap, 1, true, 5.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 2, true, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
+    testMinimize(testMap, 2, true, 2.5);
+    testMinimize(testMap, 2, false, 2.0);
+    testMinimize(testMap, 2, false, 1.0);
+    testMinimize(testMap, 2, false, 0.0);
     testMap.insert(1.0, 3, 2.0);
+    testMinimize(testMap, 1, true, 5.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 2, true, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
+    testMinimize(testMap, 2, true, 2.5);
+    testMinimize(testMap, 3, true, 2.0); //Breakpoint between 3 and 2
+    testMinimize(testMap, 3, true, 1.0);
+    testMinimize(testMap, 3, true, 0.0);
     testGetPen(testMap, 0.0);
    }
 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -341,7 +341,7 @@ TEST(InsertTests, insertSameModelSize){
     testMinimize(testMap.minimize(2.0), 5, true, 2.0);
     testMap.insert(3.0, 5, 1.0);
     testMinimize(testMap.minimize(3.0), 5, true, 3.0);
-    
+    testMinimize(testMap.minimize(0.0), 5, false, 0.0);
     //This test passes under the current insert implementation, but the memory result is not constant. TODO: Add expanded duplicate key logic to insert!
     testMap.displayMap(); 
    }

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -76,7 +76,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMinimize(testMap, 1, false, 0.5);
    }
 
-   TEST(InsertTests, testEmptyMapNoParamInsert){
+   TEST(DISABLED_InsertTests, testEmptyMapNoParamInsert){
      ModelSelectionMap testMap = ModelSelectionMap();
      testMap.insert(2,2.0);
      testMap.displayMap();
@@ -169,7 +169,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
    }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(PanelInserts, testInsertLeftPanel){
+ TEST(DISABLED_PanelInserts, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -340,12 +340,16 @@ TEST(InsertTests, insertSameModelSize){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);
+    testMap.displayPenList();
     testMap.displayMap(); 
     testMinimize(testMap, 5, true, 1.0);
+    testMap.displayPenList();
     testMap.insert(2.0, 5, 1.0);
+    testMap.displayPenList();
     testMap.displayMap(); 
     testMinimize(testMap, 5, true, 2.0);
     testMap.insert(3.0, 5, 1.0);
+    testMap.displayPenList();
     testMinimize(testMap, 5, true, 3.0);
     testMinimize(testMap, 5, false, 0.0);
     //This test passes under the current insert implementation, but the memory result is not constant. TODO: Add expanded duplicate key logic to insert!
@@ -353,7 +357,7 @@ TEST(InsertTests, insertSameModelSize){
    }
 
 
-TEST(InsertTests, insertLargeModelFirst){
+TEST(DISABLED_InsertTests, insertLargeModelFirst){
   ModelSelectionMap testMap = ModelSelectionMap();
   testMap.insert(6, 1.0);
   testMap.displayMap();

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -50,8 +50,6 @@ TEST(DISABLED_breakpointTests, testBreakFormation){
     ASSERT_EQ(breakpoint, 3.0);
 }
 
-
-
 TEST(DISABLED_breakpointTests, testGetNewPenList){
     Model model1segs = Model(1, 7);
     Model model2segs = Model(2, 4);
@@ -64,20 +62,12 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
    }
 
 
- TEST(PenaltyPairsTests, DISABLED_testBreakFormation){
-    Model testModel = Model(2, 3);
-    double expectedPen = 4.0;
-    PenaltyModelPair testBP = PenaltyModelPair(4.0, testModel);
-    ASSERT_EQ(testBP.first, expectedPen);
-   }
-
-   TEST(PenaltyPairsTests, DISABLED_testEmptyMinimization){
+   TEST(PenaltyPairsTests, testEmptyMinimization){
     ModelSelectionMap testMap = ModelSelectionMap();
     double expectedStart = 1;
-    double expectedEnd = INFINITY;
     MinimizeResult emptyResult = testMap.minimize(4.0);
-    ASSERT_EQ(emptyResult.optimalModels.first, expectedStart);
-    ASSERT_EQ(emptyResult.optimalModels.second, expectedEnd);
+    ASSERT_EQ(emptyResult.modelSize, expectedStart);
+    
    }
 
     
@@ -256,7 +246,7 @@ TEST(DISABLED_InsertTests, testInsertMiddlePanel){
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
 //TODO complete this test after the left and middle panel tests pass.
-TEST(InsertTests, testInsertRightPanelPen){
+TEST(DISABLED_InsertTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -274,12 +264,14 @@ TEST(InsertTests, testInsertRightPanelPen){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(InsertTests, testInsertRightPanel){
+TEST(DISABLED_InsertTests, testInsertRightPanel){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
     Model model3Seg = Model(3, 2.0);
+    Model model4Seg = Model(4,1.0);
     testMap.insert(1, 7.0);
+    testMap.displayMap();
     testMinimize(testMap.minimize(5.0), 1, false, 5.0);
     testMinimize(testMap.minimize(4.0), 1, false, 4.0);
     testMinimize(testMap.minimize(3.0), 1, false, 3.0);
@@ -287,21 +279,56 @@ TEST(InsertTests, testInsertRightPanel){
     testMinimize(testMap.minimize(1.0), 1, false, 1.0);
     testMinimize(testMap.minimize(0.0), 1, false, 0.0);
     testMap.insert(2, 4.0);
-    std::cout << "Breakpoint between 1 and 2: " << findBreakpoint(model1Seg, model2Seg) << "\n"; //3.0
+    testMap.displayMap();
+    std::cout << "BREAKPOINT BETWEEN 1 and 2: " << findBreakpoint(model1Seg, model2Seg) << "\n"; //3.0
     testMinimize(testMap.minimize(5.0), 1, false, 5.0);
     testMinimize(testMap.minimize(4.0), 1, false, 4.0);
     testMinimize(testMap.minimize(3.0), 1, false, 3.0); 
     testMinimize(testMap.minimize(2.0), 2, false, 2.0); //1 and two should be able to return true results after 3 is inserted. 
     testMinimize(testMap.minimize(1.0), 2, false, 1.0);
     testMinimize(testMap.minimize(0.0), 2, false, 0.0);
-    std::cout << "Breakpoint between 2 and 3: " << findBreakpoint(model2Seg, model3Seg) << "\n"; //2.0
+    std::cout << "BREAKPOINT BETWEEN 2 and 3: " << findBreakpoint(model2Seg, model3Seg) << "\n"; //2.0
     testMap.insert(3, 2.0);
     testMinimize(testMap.minimize(5.0), 1, false, 5.0);
     testMinimize(testMap.minimize(4.0), 1, false, 4.0);
     testMinimize(testMap.minimize(3.0), 1, false, 3.0); 
     testMinimize(testMap.minimize(2.0), 2, false, 2.0);
     testMinimize(testMap.minimize(1.0), 3, false, 1.0); //With a cap this an easy solution. To be true. 
-    testMinimize(testMap.minimize(0.0), 3, false, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be? 
+    testMinimize(testMap.minimize(0.0), 3, false, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
+    testMap.displayMap();
+    testMap.insert(0, 4, 0.0);
+    testMap.displayMap();
+    std::cout << "BREAKPOINT BETWEEN 3 and 4: " << findBreakpoint(model3Seg, model4Seg) << "\n\n"; //1
+    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
+    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
+    testMinimize(testMap.minimize(3.0), 1, true, 3.0); 
+    testMinimize(testMap.minimize(2.0), 2, true, 2.0);
+    testMinimize(testMap.minimize(1.0), 3, true, 1.0); //With a cap this an easy solution. To be true. 
+    testMinimize(testMap.minimize(0.0), 4, true, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
+    testMap.displayMap();
+    testGetPen(testMap, 0.0);
+   }
+//Test for right panel insertion without minimize checks to fix issues with the two param inserts.
+TEST(InsertTests, testTwoParamBreakpoints){
+    ModelSelectionMap testMap = ModelSelectionMap();
+    Model model1Seg = Model(1, 7.0);
+    Model model2Seg = Model(2, 4.0); 
+    Model model3Seg = Model(3, 2.0);
+    Model model4Seg = Model(4,1.0);
+    testMap.insert(1, 7.0);
+    testMap.displayMap();
+    std::cout << "BREAKPOINT BETWEEN 1 and 2: " << findBreakpoint(model1Seg, model2Seg) << "\n"; //3.0
+    testMap.insert(2, 4.0);
+    testMap.displayMap();
+    
+    std::cout << "BREAKPOINT BETWEEN 2 and 3: " << findBreakpoint(model2Seg, model3Seg) << "\n"; //2.0
+    
+    testMap.insert(3, 2.0);
+    testMap.displayMap();
+    std::cout << "BREAKPOINT BETWEEN 3 and 4: " << findBreakpoint(model3Seg, model4Seg) << "\n\n"; //1
+    testMap.insert(1, 4, 0.0);
+    testMap.displayMap();
+    testMap.displayMap();
     testGetPen(testMap, 0.0);
    }
 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -178,7 +178,7 @@ TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
    }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(InsertTests, testInsertLeftPanel){
+ TEST(DISABLED_InsertTests, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -211,7 +211,7 @@ TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
 
 
 //Test PenaltyModelPair insertion based on panel 2 (Middle with three models. Low start loss for #3, 2 not considered.)
-TEST(InsertTests, testInsertMiddlePanel){
+TEST(DISABLED_InsertTests, testInsertMiddlePanel){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -241,11 +241,12 @@ TEST(InsertTests, testInsertMiddlePanel){
     testMap.displayMap();
     //Add model with 3 segments that is found to be more optimal
     testMap.insert(1.0, 3, 0.0);
-    double bkpt3to2 = findBreakpoint(model3Seg, model2Seg); 
+    double bkpt3to2 = findBreakpoint(model3Seg, model2Seg);
+    testMap.displayMap(); 
     std::cout << "BREAKPOINT BETWEEN MODELS 3 AND 2 " << bkpt3to2 << "\n"; //4.0 Removed
     double bkpt3to1 = findBreakpoint(model3Seg, model1Seg); 
     std::cout << "BREAKPOINT BETWEEN MODELS 3 AND 1 " << bkpt3to1 << "\n"; //3.5
-    testMinimize(testMap.minimize(5.0), 1, true, 0.0);
+    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
     testMinimize(testMap.minimize(4.0), 1, true, 4.0);
     testMinimize(testMap.minimize(3.5), 1, true, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
     testMinimize(testMap.minimize(3.0), 3, true, 2.0);
@@ -255,17 +256,56 @@ TEST(InsertTests, testInsertMiddlePanel){
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
 //TODO complete this test after the left and middle panel tests pass.
-TEST(DISABLED_InsertTests, testInsertRightPanel){
+TEST(InsertTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
     Model model3Seg = Model(3, 2.0);
     testMap.insert(4.0, 1, 7.0);
+    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
+    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
+    testMinimize(testMap.minimize(3.0), 1, false, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
+    testMinimize(testMap.minimize(2.0), 1, false, 2.0);
+    testMinimize(testMap.minimize(1.0), 1, false, 1.0);
+    testMinimize(testMap.minimize(0.0), 1, false, 0.0);
     testMap.insert(2.5, 2, 4.0);
     testMap.insert(1.0, 3, 2.0);
     testGetPen(testMap, 0.0);
    }
+
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
+TEST(InsertTests, testInsertRightPanel){
+    ModelSelectionMap testMap = ModelSelectionMap();
+    Model model1Seg = Model(1, 7.0);
+    Model model2Seg = Model(2, 4.0); 
+    Model model3Seg = Model(3, 2.0);
+    testMap.insert(1, 7.0);
+    testMinimize(testMap.minimize(5.0), 1, false, 5.0);
+    testMinimize(testMap.minimize(4.0), 1, false, 4.0);
+    testMinimize(testMap.minimize(3.0), 1, false, 3.0);
+    testMinimize(testMap.minimize(2.0), 1, false, 2.0);
+    testMinimize(testMap.minimize(1.0), 1, false, 1.0);
+    testMinimize(testMap.minimize(0.0), 1, false, 0.0);
+    testMap.insert(2, 4.0);
+    std::cout << "Breakpoint between 1 and 2: " << findBreakpoint(model1Seg, model2Seg) << "\n"; //3.0
+    testMinimize(testMap.minimize(5.0), 1, false, 5.0);
+    testMinimize(testMap.minimize(4.0), 1, false, 4.0);
+    testMinimize(testMap.minimize(3.0), 1, false, 3.0); 
+    testMinimize(testMap.minimize(2.0), 2, false, 2.0); //1 and two should be able to return true results after 3 is inserted. 
+    testMinimize(testMap.minimize(1.0), 2, false, 1.0);
+    testMinimize(testMap.minimize(0.0), 2, false, 0.0);
+    std::cout << "Breakpoint between 2 and 3: " << findBreakpoint(model2Seg, model3Seg) << "\n"; //2.0
+    testMap.insert(3, 2.0);
+    testMinimize(testMap.minimize(5.0), 1, false, 5.0);
+    testMinimize(testMap.minimize(4.0), 1, false, 4.0);
+    testMinimize(testMap.minimize(3.0), 1, false, 3.0); 
+    testMinimize(testMap.minimize(2.0), 2, false, 2.0);
+    testMinimize(testMap.minimize(1.0), 3, false, 1.0); //With a cap this an easy solution. To be true. 
+    testMinimize(testMap.minimize(0.0), 3, false, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be? 
+    testGetPen(testMap, 0.0);
+   }
+
+//Test PenaltyModelPair insertion based on panel 2 without penalties.
 TEST(InsertTests, DISABLED_insertSameModelSize){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -18,9 +18,7 @@
 void testMinimize(MinimizeResult testResult, double lowModelSize, bool expectedCertainty, double penaltyQuery){
    //Log the test being run.
    std::string certaintyString = "";
-   
    expectedCertainty ? certaintyString = "true" : certaintyString = "false";
-    
    GTEST_MINCOUT << "Running test minimize with parameters: " << "low: " << lowModelSize << 
                      "; expectedCertainty: " << certaintyString << "; penalty: " << penaltyQuery << ";\n\n";
    //Check if the expected range of values is correct.
@@ -80,7 +78,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
      ModelSelectionMap testMap = ModelSelectionMap();
      testMap.insert(2,2.0);
      testMinimize(testMap.minimize(1.0), 2, false, 1.0);
-     EXPECT_EQ(testMap.lastInsertedPair->first, 0.0);
+     EXPECT_EQ(testMap.lastInsertedPair->first, INFINITY);
      EXPECT_EQ(testMap.lastInsertedPair->second.modelSize,2);
      EXPECT_EQ(testMap.lastInsertedPair->second.isPlaceHolder, false);
 
@@ -108,7 +106,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     //All asserts pass 6/16/20.
   }
 
-   TEST(DISABLED_InsertTests, testDuplicatePenalty){
+  TEST(DISABLED_InsertTests, testDuplicatePenalty){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model1Seg = Model(1, 7.0);
     int expectedCount = 1;
@@ -264,7 +262,7 @@ TEST(DISABLED_InsertTests, testInsertRightPanelPen){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(DISABLED_InsertTests, testInsertRightPanel){
+TEST(InsertTests, testInsertRightPanel){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -309,7 +307,7 @@ TEST(DISABLED_InsertTests, testInsertRightPanel){
     testGetPen(testMap, 0.0);
    }
 //Test for right panel insertion without minimize checks to fix issues with the two param inserts.
-TEST(InsertTests, testTwoParamBreakpoints){
+TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
     ModelSelectionMap testMap = ModelSelectionMap();
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -9,8 +9,8 @@
 #include "PartialModelSelection.hpp"
 
 //Macros to display test info in gtest format. 
-#define GTEST_MINCOUT std::cerr << "[ MINIMIZE ] [INFO] "
-#define GTEST_GETPENCOUT std::cerr << "[ GETPEN ] [INFO] "
+#define GTEST_MINCOUT std::cout << "[ MINIMIZE ] [INFO] "
+#define GTEST_GETPENCOUT std::cout << "[ GETPEN ] [INFO] "
 
 
 
@@ -237,7 +237,8 @@ TEST(InsertTests, testInsertMiddlePanel){
     testMinimize(testMap.minimize(2.0), 2, false, 2.0); //Breaks down here because placeholder model size is not updated? 7/9/2020
     testMinimize(testMap.minimize(1.0), 2, false, 1.0); //Should give us 1 or 2 for now, but the model cap is 3 so there is a chance that 2 can be overridden/not optimal.
     testMinimize(testMap.minimize(0.0), 2, false, 0.0);
-     
+    std::cout << "Testing minimize model size at zero: " << testMap.minimize(0.0).modelSize << "\n";
+    testMap.displayMap();
     //Add model with 3 segments that is found to be more optimal
     testMap.insert(1.0, 3, 0.0);
     double bkpt3to2 = findBreakpoint(model3Seg, model2Seg); 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -20,18 +20,20 @@ void testMinimize(MinimizeResult testResult, double lowModelSize, bool expectedC
    std::string certaintyString = "";
    expectedCertainty ? certaintyString = "true" : certaintyString = "false";
    GTEST_MINCOUT << "Running test minimize with parameters: " << "low: " << lowModelSize << 
-                     "; expectedCertainty: " << certaintyString << "; penalty: " << penaltyQuery << ";\n\n";
+                     "; expectedCertainty: " << certaintyString << "; penalty: " << penaltyQuery << "\n\n";
    //Check if the expected range of values is correct.
    EXPECT_EQ(lowModelSize, testResult.modelSize) << "\nMinimize first parameter is different from expected.\n";
    EXPECT_EQ(expectedCertainty, testResult.certain) << "\nMinimize certainty flag is different from expected.\n";      
 }
 
 //Testing method to test getNextPen
-void testGetPen(ModelSelectionMap testMap, double expectedPenalty ){
-    GTEST_GETPENCOUT << "Running test for getNextPenalty\n\n";
+void testGetPen(ModelSelectionMap testMap, double expectedPenalty, int index = 0 ){
+    GTEST_GETPENCOUT << "Running test for getNextPenalty with parameters: " << "expectedPen: " << expectedPenalty 
+                << "; Index: " << index << " \n\n";
     std::vector<double> currentPenList = testMap.getNewPenaltyList();
-    double firstPen = currentPenList.front();
-    EXPECT_EQ(0.0, expectedPenalty) << "Penalty returned by getNewPenalty differs from expected.\n"; 
+    testMap.displayPenList();
+    double storedPen = currentPenList.at(index);
+    EXPECT_EQ(storedPen, expectedPenalty) << "Penalty returned by getNewPenalty differs from expected.\n"; 
 }
 
 TEST(DISABLED_breakpointTests, testBreakFormation){
@@ -166,7 +168,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
    }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(DISABLED_PanelInserts, testInsertLeftPanel){
+ TEST(PanelInserts, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -196,6 +198,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMinimize(testMap.minimize(2.0), 2, true, 2.0); //These two queries return 2 for sure after we insert it at 0.0, and with the breakpoint at 3.0 computed from the loss and slope.  
     testMinimize(testMap.minimize(1.0), 2, true, 1.0);
     testMinimize(testMap.minimize(1.0), 2, true, 0.0);
+    testGetPen(testMap, 3.0, 1);
    }
 
 
@@ -245,7 +248,7 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
 //TODO complete this test after the left and middle panel tests pass.
-TEST(DISABLED_InsertTests, testInsertRightPanelPen){
+TEST(DISABLED_PanelTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -336,8 +339,10 @@ TEST(InsertTests, insertSameModelSize){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);
+    testMap.displayMap(); 
     testMinimize(testMap.minimize(1.0), 5, true, 1.0);
     testMap.insert(2.0, 5, 1.0);
+    testMap.displayMap(); 
     testMinimize(testMap.minimize(2.0), 5, true, 2.0);
     testMap.insert(3.0, 5, 1.0);
     testMinimize(testMap.minimize(3.0), 5, true, 3.0);
@@ -350,8 +355,10 @@ TEST(InsertTests, insertSameModelSize){
 TEST(InsertTests, insertLargeModelFirst){
   ModelSelectionMap testMap = ModelSelectionMap();
   testMap.insert(6, 1.0);
+  testMap.displayMap();
   testMap.insert(1,5.0);
   testMap.displayMap();
+  testMinimize(testMap.minimize(3.0), 1, false, 3.0);
 }
 
 //Driver function for google test

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -13,8 +13,6 @@
 #define GTEST_MINCOUT std::cout << "[ MINIMIZE ] [INFO] "
 #define GTEST_GETPENCOUT std::cout << "[ GETPEN ] [INFO] "
 
-
-
 //Testing method to test minimize method (minimizeResults).   
 void testMinimize(ModelSelectionMap testMap, double lowModelSize, bool expectedCertainty, double penaltyQuery){
    //Log the test being run.
@@ -173,7 +171,6 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     std::cout << "Breakpoint between 2 and 6: " << breakpoint << "\n";
     testMap.insert(2, 5.0);
     testMap.insert(6, 0.0);
-    
     testMinimize(testMap, 2, false, 5.0);
     testMinimize(testMap, 2, false, 4.0);
     testMinimize(testMap, 2, false, 3.0);
@@ -376,7 +373,7 @@ TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 without penalties.
-TEST(InsertTests, insertSameModelSize){
+TEST(InsertTests, insertSameModelSizeInOrder){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);
@@ -389,6 +386,27 @@ TEST(InsertTests, insertSameModelSize){
     testMap.displayMap(); 
     testMinimize(testMap, 5, true, 2.0);
     testMap.insert(3.0, 5, 1.0);
+    testMap.displayPenList();
+    testMinimize(testMap, 5, true, 3.0);
+    testMinimize(testMap, 5, false, 0.0);
+    //This test passes under the current insert implementation, but the memory result is not constant. TODO: Add expanded duplicate key logic to insert!
+    testMap.displayMap(); 
+   }
+
+
+   //Test PenaltyModelPair insertion based on panel 2 without penalties.
+TEST(InsertTests, insertSameModelSizeUnordered){
+    ModelSelectionMap testMap = ModelSelectionMap(6);
+    Model model5Seg = Model(5, 1.0);
+    testMap.insert(1.0, 5, 1.0);
+    testMap.displayPenList();
+    testMap.displayMap(); 
+    testMinimize(testMap, 5, true, 1.0);
+    testMap.displayPenList();
+    testMap.insert(3.0, 5, 1.0);
+    testMap.displayPenList();
+    testMap.displayMap(); 
+    testMap.insert(2.0, 5, 1.0);
     testMap.displayPenList();
     testMinimize(testMap, 5, true, 3.0);
     testMinimize(testMap, 5, false, 0.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -31,8 +31,7 @@ void testGetPen(ModelSelectionMap testMap, double expectedPenalty ){
     GTEST_GETPENCOUT << "Running test for getNextPenalty\n\n";
     std::vector<double> currentPenList = testMap.getNewPenaltyList();
     double firstPen = currentPenList.front();
-    EXPECT_EQ(0.0, expectedPenalty) << "Penalty returned by getNewPenalty differs from expected.\n";
-    
+    EXPECT_EQ(0.0, expectedPenalty) << "Penalty returned by getNewPenalty differs from expected.\n"; 
 }
 
 TEST(DISABLED_breakpointTests, testBreakFormation){
@@ -77,9 +76,10 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
    TEST(InsertTests, testEmptyMapNoParamInsert){
      ModelSelectionMap testMap = ModelSelectionMap();
      testMap.insert(2,2.0);
+     testMap.displayMap();
      testMinimize(testMap.minimize(1.0), 2, false, 1.0);
      EXPECT_EQ(testMap.lastInsertedPair->first, INFINITY);
-     EXPECT_EQ(testMap.lastInsertedPair->second.modelSize,2);
+     EXPECT_EQ(testMap.lastInsertedPair->second.modelSize,2); 
      EXPECT_EQ(testMap.lastInsertedPair->second.isPlaceHolder, false);
 
    }
@@ -166,7 +166,7 @@ TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
    }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(DISABLED_InsertTests, testInsertLeftPanel){
+ TEST(InsertTests, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -279,7 +279,7 @@ TEST(InsertTests, testInsertRightPanel){
     testMap.insert(2, 4.0);
     testMap.displayMap();
     std::cout << "BREAKPOINT BETWEEN 1 and 2: " << findBreakpoint(model1Seg, model2Seg) << "\n"; //3.0
-    testMinimize(testMap.minimize(5.0), 1, false, 5.0);
+    testMinimize(testMap.minimize(5.0), 1, false, 5.0);//BReak here
     testMinimize(testMap.minimize(4.0), 1, false, 4.0);
     testMinimize(testMap.minimize(3.0), 2, false, 3.0); 
     testMinimize(testMap.minimize(2.0), 2, false, 2.0); //1 and two should be able to return true results after 3 is inserted. 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -257,7 +257,7 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(DISABLED_PanelTests, testInsertRightPanelPen){
+TEST(PanelTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -27,11 +27,9 @@ void testMinimize(ModelSelectionMap testMap, double lowModelSize, bool expectedC
 }
 
 //Testing method to test getNextPen
-void testGetPen(ModelSelectionMap testMap, std::vector<double> expectedPenList){
-    GTEST_GETPENCOUT << "Running test for getNextPenalty\n";
-    std::vector<double> currentPenList = testMap.getNewPenaltyList();
-    testMap.displayPenList();
-    EXPECT_EQ(currentPenList, expectedPenList) << "Penalty returned by getNewPenalty differs from expected.\n"; 
+void testGetPen(double newPenalty, double expectedPen){
+    GTEST_GETPENCOUT << "Running test for getNewPenalty\n";
+    EXPECT_EQ(newPenalty, expectedPen) << "Penalty returned by getNewPenalty differs from expected.\n"; 
 }
 
 TEST(DISABLED_breakpointTests, testBreakFormation){
@@ -47,17 +45,20 @@ TEST(DISABLED_breakpointTests, testBreakFormation){
     ASSERT_EQ(breakpoint, 3.0);
 }
 
-TEST(DISABLED_breakpointTests, testGetNewPenList){
+TEST(breakpointTests, testGetNewPenList){
     Model model1segs = Model(1, 7);
     Model model2segs = Model(2, 4);
     ModelSelectionMap testMap = ModelSelectionMap();
-    std::vector<double> expectedPenalties{0, 3.0};
+    double expectedPen = 0;
     testMap.insert(2,4.0);
     testMap.insert(1, 7.0);
     double breakpoint = findBreakpoint(model1segs, model2segs);
     testMap.displayPenList();
-
-    testGetPen(testMap, expectedPenalties);
+    testGetPen(testMap.getNewPenalty(), expectedPen);
+    testMap.displayPenList();
+    expectedPen = breakpoint;
+    testGetPen(testMap.getNewPenalty(), expectedPen);
+    testMap.displayPenList();
    }
 
    TEST(DISABLED_breakpointTests, testInvalidBounds){
@@ -180,7 +181,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
   }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(PanelInserts, testInsertLeftPanel){
+ TEST(DISABLED_PanelInserts, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
@@ -256,7 +257,7 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
-TEST(PanelTests, testInsertRightPanelPen){
+TEST(DISABLED_PanelTests, testInsertRightPanelPen){
     ModelSelectionMap testMap = ModelSelectionMap(3);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
@@ -292,6 +293,7 @@ TEST(PanelTests, testInsertRightPanelPen){
 TEST(DISABLED_PanelTests, testInsertRightPanel){
     ModelSelectionMap testMap = ModelSelectionMap();
     std::vector<double> expectedPenalties{0, 3.0};
+    double expectedPen = 0;
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
     Model model3Seg = Model(3, 2.0);
@@ -332,12 +334,14 @@ TEST(DISABLED_PanelTests, testInsertRightPanel){
     testMinimize(testMap, 3, true, 1.0); //With a cap this an easy solution. To be true. 
     testMinimize(testMap, 4, true, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
     testMap.displayMap();
-    testGetPen(testMap, expectedPenalties);
+    testGetPen(testMap.getNewPenalty(), expectedPen);
+    expectedPen = 3.0;
+    testGetPen(testMap.getNewPenalty(), expectedPen);
    }
 //Test for right panel insertion without minimize checks to fix issues with the two param inserts.
 TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
     ModelSelectionMap testMap = ModelSelectionMap();
-    std::vector<double> expectedPenalties{0, 3.0};
+    double expectedPen = 0;
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0); 
     Model model3Seg = Model(3, 2.0);
@@ -355,11 +359,12 @@ TEST(DISABLED_InsertTests, testTwoParamBreakpoints){
     std::cout << "BREAKPOINT BETWEEN 3 and 4: " << findBreakpoint(model3Seg, model4Seg) << "\n\n"; //1
     testMap.insert(0, 4, 0.0);
     testMap.displayMap();
-    testGetPen(testMap, expectedPenalties);
+    testGetPen(testMap.getNewPenalty(), expectedPen);
+    expectedPen = 3.0;
+    testGetPen(testMap.getNewPenalty(), expectedPen);
    }
 
-//Test PenaltyModelPair insertion based on panel 2 without penalties.
-TEST(InsertTests, insertSameModelSizeInOrder){
+TEST(DISABLED_InsertTests, insertSameModelSizeInOrder){
     ModelSelectionMap testMap = ModelSelectionMap(6);
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -178,7 +178,7 @@ TEST(DISABLED_InsertTests, testOneParamOnePenInsertion){
    }
 
  //Test PenaltyModelPair insertion based on panel 1 (left with two models.)
- TEST(DISABLED_InsertTests, testInsertLeftPanel){
+ TEST(InsertTests, testInsertLeftPanel){
     ModelSelectionMap testMap = ModelSelectionMap(2);
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -15,8 +15,9 @@
 
 
 //Testing method to test minimize method (minimizeResults).   
-void testMinimize(MinimizeResult testResult, double lowModelSize, bool expectedCertainty, double penaltyQuery){
+void testMinimize(ModelSelectionMap testMap, double lowModelSize, bool expectedCertainty, double penaltyQuery){
    //Log the test being run.
+   MinimizeResult testResult = testMap.minimize(penaltyQuery);
    std::string certaintyString = "";
    expectedCertainty ? certaintyString = "true" : certaintyString = "false";
    GTEST_MINCOUT << "Running test minimize with parameters: " << "low: " << lowModelSize << 
@@ -44,8 +45,8 @@ TEST(DISABLED_breakpointTests, testBreakFormation){
     testMap.insert(2,4.0);
     testMap.insert(1,7.0);
     double breakpoint = findBreakpoint(model1segs, model2segs);
-    testMinimize(testMap.minimize(1.0), 2, true, 1.0);
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
+    testMinimize(testMap, 2, true, 1.0);
+    testMinimize(testMap, 1, true, 4.0);
     ASSERT_EQ(breakpoint, 3.0);
 }
 
@@ -72,14 +73,14 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     
    TEST(MinimizeTests, DISABLED_testInitialMinimization){
     ModelSelectionMap testMap = ModelSelectionMap();
-    testMinimize(testMap.minimize(0.5), 1, false, 0.5);
+    testMinimize(testMap, 1, false, 0.5);
    }
 
    TEST(InsertTests, testEmptyMapNoParamInsert){
      ModelSelectionMap testMap = ModelSelectionMap();
      testMap.insert(2,2.0);
      testMap.displayMap();
-     testMinimize(testMap.minimize(1.0), 2, false, 1.0);
+     testMinimize(testMap, 2, false, 1.0);
      EXPECT_EQ(testMap.lastInsertedPair->first, INFINITY);
      EXPECT_EQ(testMap.lastInsertedPair->second.modelSize,2); 
      EXPECT_EQ(testMap.lastInsertedPair->second.isPlaceHolder, false);
@@ -129,13 +130,13 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMap.insert(3.0, 2, 5.0);
     testMap.insert(6, 0.0);
     
-    testMinimize(testMap.minimize(5.0), 2, false, 5.0);
-    testMinimize(testMap.minimize(4.0), 2, false, 4.0);
-    testMinimize(testMap.minimize(3.0), 2, false, 3.0);
-    testMinimize(testMap.minimize(2.0), 2, false, 2.0);
-    testMinimize(testMap.minimize(1.25), 2, false, 2.0);
-    testMinimize(testMap.minimize(1.0), 6, false, 1.0);
-    testMinimize(testMap.minimize(0.0), 6, true, 0.0);
+    testMinimize(testMap, 2, false, 5.0);
+    testMinimize(testMap, 2, false, 4.0);
+    testMinimize(testMap, 2, false, 3.0);
+    testMinimize(testMap, 2, false, 2.0);
+    testMinimize(testMap, 2, false, 2.0);
+    testMinimize(testMap, 6, false, 1.0);
+    testMinimize(testMap, 6, true, 0.0);
   }
 
 
@@ -148,13 +149,13 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMap.insert(2, 5.0);
     testMap.insert(6, 0.0);
     
-    testMinimize(testMap.minimize(5.0), 2, false, 5.0);
-    testMinimize(testMap.minimize(4.0), 2, false, 4.0);
-    testMinimize(testMap.minimize(3.0), 2, false, 3.0);
-    testMinimize(testMap.minimize(2.0), 2, false, 2.0);
-    testMinimize(testMap.minimize(1.25), 2, false, 2.0);
-    testMinimize(testMap.minimize(1.0), 6, false, 1.0);
-    testMinimize(testMap.minimize(0.0), 6, true, 0.0);
+    testMinimize(testMap, 2, false, 5.0);
+    testMinimize(testMap, 2, false, 4.0);
+    testMinimize(testMap, 2, false, 3.0);
+    testMinimize(testMap, 2, false, 2.0);
+    testMinimize(testMap, 2, false, 2.0);
+    testMinimize(testMap, 6, false, 1.0);
+    testMinimize(testMap, 6, true, 0.0);
   }
 
 
@@ -173,7 +174,7 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     Model model1Seg = Model(1, 7.0);
     Model model2Seg = Model(2, 4.0);
 
-    testMinimize(testMap.minimize(5.0), 1, false, 5.0);
+    testMinimize(testMap, 1, false, 5.0);
    
     testGetPen(testMap, 0.0); //Iterator, getNewPenalty iterator? Should give us 0 to inf, so 0 to query.
 
@@ -181,23 +182,23 @@ TEST(DISABLED_breakpointTests, testGetNewPenList){
     testMap.insert(4.0, 1, 7.0); 
     //Test getNextPenalty
     testGetPen(testMap, 0.0);
-    testMinimize(testMap.minimize(5.0), 1, true, 5.0); //This should be certain as nothing will become optimal after it has been solved for a penalty value. 
+    testMinimize(testMap, 1, true, 5.0); //This should be certain as nothing will become optimal after it has been solved for a penalty value. 
     //Mimize Query here
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0); //We solved this on through the insert.
-    testMinimize(testMap.minimize(3.0), 1, false, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
-    testMinimize(testMap.minimize(2.0), 1, false, 2.0);
-    testMinimize(testMap.minimize(1.0), 1, false, 1.0);
-    testMinimize(testMap.minimize(0.0), 1, false, 0.0);
+    testMinimize(testMap, 1, true, 4.0); //We solved this on through the insert.
+    testMinimize(testMap, 1, false, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
+    testMinimize(testMap, 1, false, 2.0);
+    testMinimize(testMap, 1, false, 1.0);
+    testMinimize(testMap, 1, false, 0.0);
 
     //Insert two segment model and test again, should be complete path.  
     testMap.insert(0.0, 2, 4.0);
     testMap.displayMap();
-    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
-    testMinimize(testMap.minimize(3.0), 2, true, 3.0); //Breakpoint is at 3.0, so 2.0 and 1.0 should yield model with two segments as it was inserted with penatly 0.0
-    testMinimize(testMap.minimize(2.0), 2, true, 2.0); //These two queries return 2 for sure after we insert it at 0.0, and with the breakpoint at 3.0 computed from the loss and slope.  
-    testMinimize(testMap.minimize(1.0), 2, true, 1.0);
-    testMinimize(testMap.minimize(1.0), 2, true, 0.0);
+    testMinimize(testMap, 1, true, 5.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 2, true, 3.0); //Breakpoint is at 3.0, so 2.0 and 1.0 should yield model with two segments as it was inserted with penatly 0.0
+    testMinimize(testMap, 2, true, 2.0); //These two queries return 2 for sure after we insert it at 0.0, and with the breakpoint at 3.0 computed from the loss and slope.  
+    testMinimize(testMap, 2, true, 1.0);
+    testMinimize(testMap, 2, true, 0.0);
     testGetPen(testMap, 3.0, 1);
    }
 
@@ -211,24 +212,24 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
     std::cout << "BREAKPOINT BETWEEN MODELS 2 AND 1 " << bkpt2to1 << "\n"; //3.0
     Model model3Seg = Model(3, 0.0);
     testMap.insert(4.0, 1, 7.0);
-    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
-    testMinimize(testMap.minimize(3.0), 1, false, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
-    testMinimize(testMap.minimize(2.0), 1, false, 2.0);
-    testMinimize(testMap.minimize(1.0), 1, false, 1.0);
-    testMinimize(testMap.minimize(0.0), 1, false, 0.0);
+    testMinimize(testMap, 1, true, 5.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 1, false, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
+    testMinimize(testMap, 1, false, 2.0);
+    testMinimize(testMap, 1, false, 1.0);
+    testMinimize(testMap, 1, false, 0.0);
     
     //Add model with 2 segments that is found to be less optimal later on as the model cap is still 3. 
 
     testMap.insert(2, 4.0); //Need to compute breakpoint first?
-    testMinimize(testMap.minimize(5.0), 1, true, 0.0);
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
-    testMinimize(testMap.minimize(3.0), 2, true, 3.0); //Here the breakpoint between 1 and 2 segs is, at 3.0
+    testMinimize(testMap, 1, true, 0.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 2, true, 3.0); //Here the breakpoint between 1 and 2 segs is, at 3.0
     std::cout << "MIDDLE BREAK\n";
     testMap.displayMap();
-    testMinimize(testMap.minimize(2.0), 2, false, 2.0); //Breaks down here because placeholder model size is not updated? 7/9/2020
-    testMinimize(testMap.minimize(1.0), 2, false, 1.0); //Should give us 1 or 2 for now, but the model cap is 3 so there is a chance that 2 can be overridden/not optimal.
-    testMinimize(testMap.minimize(0.0), 2, false, 0.0);
+    testMinimize(testMap, 2, false, 2.0); //Breaks down here because placeholder model size is not updated? 7/9/2020
+    testMinimize(testMap, 2, false, 1.0); //Should give us 1 or 2 for now, but the model cap is 3 so there is a chance that 2 can be overridden/not optimal.
+    testMinimize(testMap, 2, false, 0.0);
     std::cout << "Testing minimize model size at zero: " << testMap.minimize(0.0).modelSize << "\n";
     testMap.displayMap();
     //Add model with 3 segments that is found to be more optimal
@@ -238,12 +239,12 @@ TEST(DISABLED_PanelTests, testInsertMiddlePanel){
     std::cout << "BREAKPOINT BETWEEN MODELS 3 AND 2 " << bkpt3to2 << "\n"; //4.0 Removed
     double bkpt3to1 = findBreakpoint(model3Seg, model1Seg); 
     std::cout << "BREAKPOINT BETWEEN MODELS 3 AND 1 " << bkpt3to1 << "\n"; //3.5
-    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
-    testMinimize(testMap.minimize(3.5), 1, true, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
-    testMinimize(testMap.minimize(3.0), 3, true, 2.0);
-    testMinimize(testMap.minimize(1.0), 3, true, 1.0); //Should give us 1 or 2 for now, but the model cap is 3 so there is a chance that 2 can be overridden/not optimal.
-    testMinimize(testMap.minimize(0.0), 3, true, 0.0); 
+    testMinimize(testMap, 1, true, 5.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 1, true, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
+    testMinimize(testMap, 3, true, 2.0);
+    testMinimize(testMap, 3, true, 1.0); //Should give us 1 or 2 for now, but the model cap is 3 so there is a chance that 2 can be overridden/not optimal.
+    testMinimize(testMap, 3, true, 0.0); 
    }
 
 //Test PenaltyModelPair insertion based on panel 2 (Right with three models. Higher start loss for #3, all models considered on path.)
@@ -254,12 +255,12 @@ TEST(DISABLED_PanelTests, testInsertRightPanelPen){
     Model model2Seg = Model(2, 4.0); 
     Model model3Seg = Model(3, 2.0);
     testMap.insert(4.0, 1, 7.0);
-    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
-    testMinimize(testMap.minimize(3.0), 1, false, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
-    testMinimize(testMap.minimize(2.0), 1, false, 2.0);
-    testMinimize(testMap.minimize(1.0), 1, false, 1.0);
-    testMinimize(testMap.minimize(0.0), 1, false, 0.0);
+    testMinimize(testMap, 1, true, 5.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 1, false, 3.0); //We only have 1 currently, but more inserts are possible with our cap of three models (which is std).
+    testMinimize(testMap, 1, false, 2.0);
+    testMinimize(testMap, 1, false, 1.0);
+    testMinimize(testMap, 1, false, 0.0);
     testMap.insert(2.5, 2, 4.0);
     testMap.insert(1.0, 3, 2.0);
     testGetPen(testMap, 0.0);
@@ -274,39 +275,39 @@ TEST(DISABLED_PanelTests, testInsertRightPanel){
     Model model4Seg = Model(4,1.0);
     testMap.insert(1, 7.0);
     testMap.displayMap();
-    testMinimize(testMap.minimize(5.0), 1, false, 5.0);
-    testMinimize(testMap.minimize(4.0), 1, false, 4.0);
-    testMinimize(testMap.minimize(3.0), 1, false, 3.0);
-    testMinimize(testMap.minimize(2.0), 1, false, 2.0);
-    testMinimize(testMap.minimize(1.0), 1, false, 1.0);
-    testMinimize(testMap.minimize(0.0), 1, false, 0.0);
+    testMinimize(testMap, 1, false, 5.0);
+    testMinimize(testMap, 1, false, 4.0);
+    testMinimize(testMap, 1, false, 3.0);
+    testMinimize(testMap, 1, false, 2.0);
+    testMinimize(testMap, 1, false, 1.0);
+    testMinimize(testMap, 1, false, 0.0);
     testMap.insert(2, 4.0);
     testMap.displayMap();
     std::cout << "BREAKPOINT BETWEEN 1 and 2: " << findBreakpoint(model1Seg, model2Seg) << "\n"; //3.0
-    testMinimize(testMap.minimize(5.0), 1, false, 5.0);//BReak here
-    testMinimize(testMap.minimize(4.0), 1, false, 4.0);
-    testMinimize(testMap.minimize(3.0), 2, false, 3.0); 
-    testMinimize(testMap.minimize(2.0), 2, false, 2.0); //1 and two should be able to return true results after 3 is inserted. 
-    testMinimize(testMap.minimize(1.0), 2, false, 1.0);
-    testMinimize(testMap.minimize(0.0), 2, false, 0.0);
+    testMinimize(testMap, 1, false, 5.0);//BReak here
+    testMinimize(testMap, 1, false, 4.0);
+    testMinimize(testMap, 2, false, 3.0); 
+    testMinimize(testMap, 2, false, 2.0); //1 and two should be able to return true results after 3 is inserted. 
+    testMinimize(testMap, 2, false, 1.0);
+    testMinimize(testMap, 2, false, 0.0);
     std::cout << "BREAKPOINT BETWEEN 2 and 3: " << findBreakpoint(model2Seg, model3Seg) << "\n"; //2.0
     testMap.insert(3, 2.0);
-    testMinimize(testMap.minimize(5.0), 1, false, 5.0);
-    testMinimize(testMap.minimize(4.0), 1, false, 4.0);
-    testMinimize(testMap.minimize(3.0), 2, false, 3.0); 
-    testMinimize(testMap.minimize(2.0), 3, false, 2.0);
-    testMinimize(testMap.minimize(1.0), 3, false, 1.0); //With a cap this an easy solution. To be true. 
-    testMinimize(testMap.minimize(0.0), 3, false, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
+    testMinimize(testMap, 1, false, 5.0);
+    testMinimize(testMap, 1, false, 4.0);
+    testMinimize(testMap, 2, false, 3.0); 
+    testMinimize(testMap, 3, false, 2.0);
+    testMinimize(testMap, 3, false, 1.0); //With a cap this an easy solution. To be true. 
+    testMinimize(testMap, 3, false, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
     testMap.displayMap();
     testMap.insert(0, 4, 0.0);
     testMap.displayMap();
     std::cout << "BREAKPOINT BETWEEN 3 and 4: " << findBreakpoint(model3Seg, model4Seg) << "\n\n"; //1
-    testMinimize(testMap.minimize(5.0), 1, true, 5.0);
-    testMinimize(testMap.minimize(4.0), 1, true, 4.0);
-    testMinimize(testMap.minimize(3.0), 1, true, 3.0); 
-    testMinimize(testMap.minimize(2.0), 2, true, 2.0);
-    testMinimize(testMap.minimize(1.0), 3, true, 1.0); //With a cap this an easy solution. To be true. 
-    testMinimize(testMap.minimize(0.0), 4, true, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
+    testMinimize(testMap, 1, true, 5.0);
+    testMinimize(testMap, 1, true, 4.0);
+    testMinimize(testMap, 1, true, 3.0); 
+    testMinimize(testMap, 2, true, 2.0);
+    testMinimize(testMap, 3, true, 1.0); //With a cap this an easy solution. To be true. 
+    testMinimize(testMap, 4, true, 0.0); //This will likely never be true in this case with an infinite cap. Does it need to be?
     testMap.displayMap();
     testGetPen(testMap, 0.0);
    }
@@ -340,13 +341,13 @@ TEST(InsertTests, insertSameModelSize){
     Model model5Seg = Model(5, 1.0);
     testMap.insert(1.0, 5, 1.0);
     testMap.displayMap(); 
-    testMinimize(testMap.minimize(1.0), 5, true, 1.0);
+    testMinimize(testMap, 5, true, 1.0);
     testMap.insert(2.0, 5, 1.0);
     testMap.displayMap(); 
-    testMinimize(testMap.minimize(2.0), 5, true, 2.0);
+    testMinimize(testMap, 5, true, 2.0);
     testMap.insert(3.0, 5, 1.0);
-    testMinimize(testMap.minimize(3.0), 5, true, 3.0);
-    testMinimize(testMap.minimize(0.0), 5, false, 0.0);
+    testMinimize(testMap, 5, true, 3.0);
+    testMinimize(testMap, 5, false, 0.0);
     //This test passes under the current insert implementation, but the memory result is not constant. TODO: Add expanded duplicate key logic to insert!
     testMap.displayMap(); 
    }
@@ -358,7 +359,7 @@ TEST(InsertTests, insertLargeModelFirst){
   testMap.displayMap();
   testMap.insert(1,5.0);
   testMap.displayMap();
-  testMinimize(testMap.minimize(3.0), 1, false, 3.0);
+  testMinimize(testMap, 1, false, 3.0);
 }
 
 //Driver function for google test

--- a/src/PartialModelSelectionMain.cpp
+++ b/src/PartialModelSelectionMain.cpp
@@ -45,7 +45,7 @@ TEST(DISABLED_breakpointTests, testBreakFormation){
     ASSERT_EQ(breakpoint, 3.0);
 }
 
-TEST(breakpointTests, testGetNewPenList){
+TEST(DISABLED_breakpointTests, testGetNewPenList){
     Model model1segs = Model(1, 7);
     Model model2segs = Model(2, 4);
     ModelSelectionMap testMap = ModelSelectionMap();


### PR DESCRIPTION
At this point, the insert with penalty, modelSize, and loss builds the correct path for the left panel, and most of the right one, saving some breakpoint boundaries that need to be enlarged, which is TODO. Middle panel does not work yet because I am still developing an update rule for removing the no longer optimal model of size 2. 

See figure 1 for background: https://github.com/tdhock/changepoint-data-structure/blob/master/figures.pdf